### PR TITLE
add delete method and specs for users controller

### DIFF
--- a/app/controllers/concerns/scim_rails/response.rb
+++ b/app/controllers/concerns/scim_rails/response.rb
@@ -21,6 +21,11 @@ module ScimRails
           json: user_response(object),
           status: status,
           content_type: CONTENT_TYPE
+      when "delete"
+        render \
+          nothing: true,
+          status: status,
+          content_type: CONTENT_TYPE
       end
     end
 

--- a/app/controllers/concerns/scim_rails/response.rb
+++ b/app/controllers/concerns/scim_rails/response.rb
@@ -22,10 +22,7 @@ module ScimRails
           status: status,
           content_type: CONTENT_TYPE
       when "delete"
-        render \
-          nothing: true,
-          status: status,
-          content_type: CONTENT_TYPE
+        head status
       end
     end
 

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -62,6 +62,12 @@ module ScimRails
       json_scim_response(object: user)
     end
 
+    def delete
+      @company.public_send(ScimRails.config.scim_users_scope).delete(params[:id])
+      ScimRails.config.scim_users_model.delete(params[:id])
+      json_scim_response(object: nil, status: :no_content)
+    end
+
     private
 
     def permitted_user_params

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -63,8 +63,8 @@ module ScimRails
     end
 
     def delete
-      @company.public_send(ScimRails.config.scim_users_scope).delete(params[:id])
-      ScimRails.config.scim_users_model.delete(params[:id])
+      user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
+      user.delete
       json_scim_response(object: nil, status: :no_content)
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 ScimRails::Engine.routes.draw do
-  get    'scim/v2/Users',      action: :index,         controller: 'scim_users'
-  post   'scim/v2/Users',      action: :create,        controller: 'scim_users'
-  get    'scim/v2/Users/:id',  action: :show,          controller: 'scim_users'
-  put    'scim/v2/Users/:id',  action: :put_update,    controller: 'scim_users'
-  patch  'scim/v2/Users/:id',  action: :patch_update,  controller: 'scim_users'
+  get     'scim/v2/Users',      action: :index,         controller: 'scim_users'
+  post    'scim/v2/Users',      action: :create,        controller: 'scim_users'
+  get     'scim/v2/Users/:id',  action: :show,          controller: 'scim_users'
+  put     'scim/v2/Users/:id',  action: :put_update,    controller: 'scim_users'
+  patch   'scim/v2/Users/:id',  action: :patch_update,  controller: 'scim_users'
+  delete  'scim/v2/Users/:id',  action: :delete,        controller: 'scim_users'
 end

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -596,7 +596,6 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
     context 'when authorized' do
       let(:user_id) { 1 }
       let(:invalid_id) { "invalid_id" }
-      let(:unauthorized_id) { 2 }
 
       let!(:user) { create(:user, id: user_id, company: company) }
 
@@ -610,20 +609,23 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
         expect(response.status).to eq(404)
       end
 
-      it "returns :not_found for correct id but unauthorized company" do
-        new_company = create(:company)
-        create(:user, company: new_company, id: unauthorized_id)
+      context "with unauthorized user" do
+        let(:unauthorized_id) { 2 }
 
-        delete :delete, { id: unauthorized_id }
-        
-        expect(response.status).to eq(404)
+        let!(:new_company) { create(:company) }
+        let!(:unauthorized_user) { create(:user, company: new_company, id: unauthorized_id) }
+
+        it "returns :not_found for correct id but unauthorized company" do
+          delete :delete, { id: unauthorized_id }
+          
+          expect(response.status).to eq(404)
+        end
       end
 
       it "successfully deletes for correct id provided" do
         delete :delete, { id: user_id }
 
         expect(response.status).to eq(204)
-        expect(company.users.count).to eq(0)
         expect(User.count).to eq(0)
       end
     end

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -572,6 +572,63 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
     end
   end
 
+
+  describe "delete" do
+    let(:company) { create(:company) }
+  
+    context "when unauthorized" do
+      before { delete :delete, { id: 1 } }
+
+      it "returns scim+json content type" do
+        expect(response.content_type).to eq "application/scim+json"
+      end
+
+      it "fails with no credentials" do
+        expect(response.status).to eq 401
+      end
+
+      it "fails with invalid credentials" do
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials("unauthorized","123456")
+        expect(response.status).to eq 401
+      end
+    end
+
+    context 'when authorized' do
+      let(:user_id) { 1 }
+      let(:invalid_id) { "invalid_id" }
+      let(:unauthorized_id) { 2 }
+
+      let!(:user) { create(:user, id: user_id, company: company) }
+
+      before :each do
+        http_login(company)
+      end
+
+      it "returns :not_found for invalid id" do
+        delete :delete, { id: invalid_id }
+
+        expect(response.status).to eq(404)
+      end
+
+      it "returns :not_found for correct id but unauthorized company" do
+        new_company = create(:company)
+        create(:user, company: new_company, id: unauthorized_id)
+
+        delete :delete, { id: unauthorized_id }
+        
+        expect(response.status).to eq(404)
+      end
+
+      it "successfully deletes for correct id provided" do
+        delete :delete, { id: user_id }
+
+        expect(response.status).to eq(204)
+        expect(company.users.count).to eq(0)
+        expect(User.count).to eq(0)
+      end
+    end
+  end
+
   def patch_params(id:, active: false)
     {
       id: id,


### PR DESCRIPTION
## Why?

As the user controller did not have a DELETE method yet, this PR aims to add one.  Unlike the `patch_update` method which simply deactivates the user, this DELETE method removes the user from the database entirely.

## What?

Created new endpoint for DELETE.  Added DELETE method to `scim_users_controller`.  Added specs to test said DELETE method
