### PR TITLE
Create callback hooks for SCIM controller methods

### DIFF
--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -1,7 +1,7 @@
 module ScimRails
   class ScimGroupsController < ScimRails::ApplicationController
     def index
-      ScimRails.config.before_scim_response.call(request.params)
+      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
       if params[:filter].present?
         query = ScimRails::ScimQueryParser.new(params[:filter])
@@ -20,13 +20,13 @@ module ScimRails
         total: groups.count
       )
 
-      ScimRails.config.after_scim_response.call(groups, "RETRIEVED")
+      ScimRails.config.after_scim_response.call(groups, "RETRIEVED") unless ScimRails.config.after_scim_response.nil?
 
       json_scim_group_response(object: groups, counts: counts)
     end
 
     def create
-      ScimRails.config.before_scim_response.call(request.params)
+      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
       group_attributes = permitted_group_params(params)
 
@@ -44,23 +44,23 @@ module ScimRails
 
       update_group_status(group) unless put_active_param.nil?
 
-      ScimRails.config.after_scim_response.call(group, "CREATED")
+      ScimRails.config.after_scim_response.call(group, "CREATED") unless ScimRails.config.after_scim_response.nil?
 
       json_scim_group_response(object: group, status: :created)
     end
 
     def show
-      ScimRails.config.before_scim_response.call(request.params)
+      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
       group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
 
-      ScimRails.config.after_scim_response.call(group, "RETRIEVED")
+      ScimRails.config.after_scim_response.call(group, "RETRIEVED") unless ScimRails.config.after_scim_response.nil?
 
       json_scim_group_response(object: group)
     end
 
     def put_update
-      ScimRails.config.before_scim_response.call(request.params)
+      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
       group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
 
@@ -76,13 +76,13 @@ module ScimRails
       group.public_send(ScimRails.config.scim_group_member_scope).clear
       add_members(group, member_ids)
 
-      ScimRails.config.after_scim_response.call(group, "UPDATED")
+      ScimRails.config.after_scim_response.call(group, "UPDATED") unless ScimRails.config.after_scim_response.nil?
 
       json_scim_group_response(object: group)
     end
 
     def patch_update
-      ScimRails.config.before_scim_response.call(request.params)
+      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
       group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
 
@@ -99,18 +99,18 @@ module ScimRails
         end
       end
 
-      ScimRails.config.after_scim_response.call(group, "UPDATED")
+      ScimRails.config.after_scim_response.call(group, "UPDATED") unless ScimRails.config.after_scim_response.nil?
 
       json_scim_group_response(object: group)
     end
 
     def delete
-      ScimRails.config.before_scim_response.call(request.params)
+      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
       group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
       group.delete
 
-      ScimRails.config.after_scim_response.call(group, "DELETED")
+      ScimRails.config.after_scim_response.call(group, "DELETED") unless ScimRails.config.after_scim_response.nil?
 
       json_scim_group_response(object: nil, status: :no_content)
     end

--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -1,6 +1,8 @@
 module ScimRails
   class ScimGroupsController < ScimRails::ApplicationController
     def index
+      ScimRails.config.before_scim_response.call(request.params)
+
       if params[:filter].present?
         query = ScimRails::ScimQueryParser.new(params[:filter])
 
@@ -18,10 +20,14 @@ module ScimRails
         total: groups.count
       )
 
+      ScimRails.config.after_scim_response.call(groups, "RETRIEVED")
+
       json_scim_group_response(object: groups, counts: counts)
     end
 
     def create
+      ScimRails.config.before_scim_response.call(request.params)
+
       group_attributes = permitted_group_params(params)
 
       if ScimRails.config.scim_group_prevent_update_on_create
@@ -37,15 +43,25 @@ module ScimRails
       end
 
       update_group_status(group) unless put_active_param.nil?
+
+      ScimRails.config.after_scim_response.call(group, "CREATED")
+
       json_scim_group_response(object: group, status: :created)
     end
 
     def show
+      ScimRails.config.before_scim_response.call(request.params)
+
       group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
+
+      ScimRails.config.after_scim_response.call(group, "RETRIEVED")
+
       json_scim_group_response(object: group)
     end
 
     def put_update
+      ScimRails.config.before_scim_response.call(request.params)
+
       group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
 
       put_error_check
@@ -60,10 +76,14 @@ module ScimRails
       group.public_send(ScimRails.config.scim_group_member_scope).clear
       add_members(group, member_ids)
 
+      ScimRails.config.after_scim_response.call(group, "UPDATED")
+
       json_scim_group_response(object: group)
     end
 
     def patch_update
+      ScimRails.config.before_scim_response.call(request.params)
+
       group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
 
       params["Operations"].each do |operation|
@@ -79,12 +99,19 @@ module ScimRails
         end
       end
 
+      ScimRails.config.after_scim_response.call(group, "UPDATED")
+
       json_scim_group_response(object: group)
     end
 
     def delete
+      ScimRails.config.before_scim_response.call(request.params)
+
       group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
       group.delete
+
+      ScimRails.config.after_scim_response.call(group, "DELETED")
+
       json_scim_group_response(object: nil, status: :no_content)
     end
 

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -1,6 +1,8 @@
 module ScimRails
   class ScimUsersController < ScimRails::ApplicationController
     def index
+      ScimRails.config.before_scim_response.call(request.params)
+
       if params[:filter].present?
         query = ScimRails::ScimQueryParser.new(params[:filter])
 
@@ -23,10 +25,14 @@ module ScimRails
         total: users.count
       )
 
+      ScimRails.config.after_scim_response.call(users, "RETRIEVED")
+
       json_scim_response(object: users, counts: counts)
     end
 
     def create
+      ScimRails.config.before_scim_response.call(request.params)
+
       if ScimRails.config.scim_user_prevent_update_on_create
         user = @company.public_send(ScimRails.config.scim_users_scope).create!(permitted_params(params))
       else
@@ -42,22 +48,37 @@ module ScimRails
         user.update!(permitted_user_params)
       end
       update_status(user) unless put_active_param.nil?
+
+      ScimRails.config.after_scim_response.call(user, "CREATED")
+
       json_scim_response(object: user, status: :created)
     end
 
     def show
+      ScimRails.config.before_scim_response.call(request.params)
+
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
+
+      ScimRails.config.after_scim_response.call(user, "RETRIEVED")
+
       json_scim_response(object: user)
     end
 
     def put_update
+      ScimRails.config.before_scim_response.call(request.params)
+
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
       update_status(user) unless put_active_param.nil?
       user.update!(permitted_params(params))
+
+      ScimRails.config.after_scim_response.call(user, "UPDATED")
+
       json_scim_response(object: user)
     end
 
     def patch_update
+      ScimRails.config.before_scim_response.call(request.params)
+
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
 
       params["Operations"].each do |operation|
@@ -76,12 +97,19 @@ module ScimRails
         user.public_send(provision_method)
       end
 
+      ScimRails.config.after_scim_response.call(user, "UPDATED")
+
       json_scim_response(object: user)
     end
 
     def delete
+      ScimRails.config.before_scim_response.call(request.params)
+
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
       user.delete
+
+      ScimRails.config.after_scim_response.call(user, "DELETED")
+
       json_scim_response(object: nil, status: :no_content)
     end
 

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -1,7 +1,7 @@
 module ScimRails
   class ScimUsersController < ScimRails::ApplicationController
     def index
-      ScimRails.config.before_scim_response.call(request.params)
+      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
       if params[:filter].present?
         query = ScimRails::ScimQueryParser.new(params[:filter])
@@ -25,13 +25,13 @@ module ScimRails
         total: users.count
       )
 
-      ScimRails.config.after_scim_response.call(users, "RETRIEVED")
+      ScimRails.config.after_scim_response.call(users, "RETRIEVED") unless ScimRails.config.after_scim_response.nil?
 
       json_scim_response(object: users, counts: counts)
     end
 
     def create
-      ScimRails.config.before_scim_response.call(request.params)
+      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
       if ScimRails.config.scim_user_prevent_update_on_create
         user = @company.public_send(ScimRails.config.scim_users_scope).create!(permitted_params(params))
@@ -49,35 +49,35 @@ module ScimRails
       end
       update_status(user) unless put_active_param.nil?
 
-      ScimRails.config.after_scim_response.call(user, "CREATED")
+      ScimRails.config.after_scim_response.call(user, "CREATED") unless ScimRails.config.after_scim_response.nil?
 
       json_scim_response(object: user, status: :created)
     end
 
     def show
-      ScimRails.config.before_scim_response.call(request.params)
+      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
 
-      ScimRails.config.after_scim_response.call(user, "RETRIEVED")
+      ScimRails.config.after_scim_response.call(user, "RETRIEVED") unless ScimRails.config.after_scim_response.nil?
 
       json_scim_response(object: user)
     end
 
     def put_update
-      ScimRails.config.before_scim_response.call(request.params)
+      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
       update_status(user) unless put_active_param.nil?
       user.update!(permitted_params(params))
 
-      ScimRails.config.after_scim_response.call(user, "UPDATED")
+      ScimRails.config.after_scim_response.call(user, "UPDATED") unless ScimRails.config.after_scim_response.nil?
 
       json_scim_response(object: user)
     end
 
     def patch_update
-      ScimRails.config.before_scim_response.call(request.params)
+      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
 
@@ -97,18 +97,18 @@ module ScimRails
         user.public_send(provision_method)
       end
 
-      ScimRails.config.after_scim_response.call(user, "UPDATED")
+      ScimRails.config.after_scim_response.call(user, "UPDATED") unless ScimRails.config.after_scim_response.nil?
 
       json_scim_response(object: user)
     end
 
     def delete
-      ScimRails.config.before_scim_response.call(request.params)
+      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
       user.delete
 
-      ScimRails.config.after_scim_response.call(user, "DELETED")
+      ScimRails.config.after_scim_response.call(user, "DELETED") unless ScimRails.config.after_scim_response.nil?
 
       json_scim_response(object: nil, status: :no_content)
     end

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -128,4 +128,26 @@ ScimRails.configure do |config|
     :displayName,
     :members
   }
+
+  # Callback hook that will be called at the beginning of
+  # each controller method. Will take the body of a given
+  # request, i.e., the params, action, controller, etc.
+  # This hook can be used for logging information to help
+  # with troubleshooting but can be left nil or commented
+  # out if it is not needed.
+  config.before_scim_response = lambda do |body|
+    print "BEFORE SCIM RESPONSE #{body}"
+  end
+
+  # Callback hook that will be called at the end of each
+  # controller method, given that the request was
+  # successful and no errors occured. Will take the object
+  # that was retrieved/create/updated/deleted its status
+  # ("RETRIEVED", "CREATED", "UPDATED", "DELETED").
+  # This hook can be used for logging information to help
+  # troubleshoot but can be left nil or commented out if
+  # it is not needed.
+  config.after_scim_response = lambda do |object, status|
+    print "#{object} #{status}"
+  end
 end

--- a/lib/scim_rails/config.rb
+++ b/lib/scim_rails/config.rb
@@ -41,7 +41,9 @@ module ScimRails
       :user_schema,
       :group_schema,
       :group_member_schema,
-      :group_attributes
+      :group_attributes,
+      :before_scim_response,
+      :after_scim_response,
 
     def initialize
       @basic_auth_model = "Company"

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     company
     users { [] }
 
-    display_name { Faker::Name.name }
-    email { Faker::Internet.email }
+    sequence(:display_name) { |n| "#{Faker::Name.name}#{n}" }
+    sequence(:email) { |n| "#{Faker::Internet.email}#{n}" }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :user do
     company
 
-    first_name { Faker::Name.first_name }
-    last_name { Faker::Name.last_name }
+    sequence(:first_name) { |n| "#{Faker::Name.first_name}#{n}" }
+    sequence(:last_name) { |n| "#{Faker::Name.last_name}#{n}" }
     sequence(:email) { |n| "#{n}@example.com" }
   end
 end

--- a/spec/support/scim_rails_config.rb
+++ b/spec/support/scim_rails_config.rb
@@ -98,4 +98,12 @@ ScimRails.configure do |config|
     value: :id
   }
 
+  config.before_scim_response = lambda do |body|
+    puts "BEFORE SCIM REQUEST #{body}"
+  end
+
+  config.after_scim_response = lambda do |object, status|
+    puts "#{object} #{status}"
+  end
+
 end

--- a/spec/support/scim_rails_config.rb
+++ b/spec/support/scim_rails_config.rb
@@ -98,12 +98,12 @@ ScimRails.configure do |config|
     value: :id
   }
 
-  # config.before_scim_response = lambda do |body|
-  #   print "BEFORE SCIM RESPONSE #{body}"
-  # end
+  config.before_scim_response = lambda do |body|
+    print "BEFORE SCIM RESPONSE #{body}"
+  end
 
-  # config.after_scim_response = lambda do |object, status|
-  #   print "#{object} #{status}"
-  # end
+  config.after_scim_response = lambda do |object, status|
+    print "#{object} #{status}"
+  end
 
 end

--- a/spec/support/scim_rails_config.rb
+++ b/spec/support/scim_rails_config.rb
@@ -98,12 +98,12 @@ ScimRails.configure do |config|
     value: :id
   }
 
-  config.before_scim_response = lambda do |body|
-    puts "BEFORE SCIM REQUEST #{body}"
-  end
+  # config.before_scim_response = lambda do |body|
+  #   print "BEFORE SCIM RESPONSE #{body}"
+  # end
 
-  config.after_scim_response = lambda do |object, status|
-    puts "#{object} #{status}"
-  end
+  # config.after_scim_response = lambda do |object, status|
+  #   print "#{object} #{status}"
+  # end
 
 end


### PR DESCRIPTION
## Why?

With the SCIM integration in production on Traction Guest, we want a better way of troubleshooting problems if they come up.  This PR adds callbacks which are fired at the beginning and end of all SCIM controller methods, to log information which can help us solve problems in the future.

## What?

* Add two callbacks to the config: `before_scim_response` and `after_scim_response`
  * `before_scim_response` will be called at the start of all SCIM controller methods.  For us, we will use it to log information about request, i.e., params
  * `after_scim_response` will be called at the end of all SCIM controller methods.  For us, we will use it to log information about the object which was retrieved, created, updated, or deleted