### PR TITLE
Feature/configurable canonical ref

### DIFF
--- a/app/controllers/scim_rails/application_controller.rb
+++ b/app/controllers/scim_rails/application_controller.rb
@@ -88,5 +88,13 @@ module ScimRails
       raise ScimRails::ExceptionHandler::UnsupportedPatchRequest if active.nil?
       active
     end
+
+    def initial_callback_hook(arg)
+      ScimRails.config.before_scim_response.call(arg) unless ScimRails.config.before_scim_response.nil?
+    end
+
+    def final_callback_hook(arg, status)
+      ScimRails.config.after_scim_response.call(arg, status) unless ScimRails.config.after_scim_response.nil?
+    end
   end
 end

--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -1,7 +1,7 @@
 module ScimRails
   class ScimGroupsController < ScimRails::ApplicationController
     def index
-      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
+      initial_callback_hook(request.params)
 
       if params[:filter].present?
         query = ScimRails::ScimQueryParser.new(params[:filter])
@@ -20,13 +20,13 @@ module ScimRails
         total: groups.count
       )
 
-      ScimRails.config.after_scim_response.call(groups, "RETRIEVED") unless ScimRails.config.after_scim_response.nil?
+      final_callback_hook(groups, "RETRIEVED")
 
       json_scim_group_response(object: groups, counts: counts)
     end
 
     def create
-      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
+      initial_callback_hook(request.params)
 
       group_attributes = permitted_group_params(params)
 
@@ -44,25 +44,25 @@ module ScimRails
 
       update_group_status(group) unless put_active_param.nil?
 
-      ScimRails.config.after_scim_response.call(group, "CREATED") unless ScimRails.config.after_scim_response.nil?
+      final_callback_hook(group, "CREATED")
 
       json_scim_group_response(object: group, status: :created)
     end
 
     def show
-      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
+      initial_callback_hook(request.params)
 
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
+      group = group_find(params[:id])
 
-      ScimRails.config.after_scim_response.call(group, "RETRIEVED") unless ScimRails.config.after_scim_response.nil?
+      final_callback_hook(group, "RETRIEVED")
 
       json_scim_group_response(object: group)
     end
 
     def put_update
-      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
+      initial_callback_hook(request.params)
 
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
+      group = group_find(params[:id])
 
       put_error_check
 
@@ -76,15 +76,15 @@ module ScimRails
       group.public_send(ScimRails.config.scim_group_member_scope).clear
       add_members(group, member_ids)
 
-      ScimRails.config.after_scim_response.call(group, "UPDATED") unless ScimRails.config.after_scim_response.nil?
+      final_callback_hook(group, "UPDATED")
 
       json_scim_group_response(object: group)
     end
 
     def patch_update
-      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
+      initial_callback_hook(request.params)
 
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
+      group = group_find(params[:id])
 
       params["Operations"].each do |operation|
         case operation["op"]
@@ -99,23 +99,27 @@ module ScimRails
         end
       end
 
-      ScimRails.config.after_scim_response.call(group, "UPDATED") unless ScimRails.config.after_scim_response.nil?
+      final_callback_hook(group, "UPDATED")
 
       json_scim_group_response(object: group)
     end
 
     def delete
-      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
+      initial_callback_hook(request.params)
 
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
+      group = group_find(params[:id])
       group.delete
 
-      ScimRails.config.after_scim_response.call(group, "DELETED") unless ScimRails.config.after_scim_response.nil?
+      final_callback_hook(group, "DELETED")
 
       json_scim_group_response(object: nil, status: :no_content)
     end
 
     private
+
+    def group_find(term)
+      @company.public_send(ScimRails.config.scim_groups_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{term}\""
+    end
 
     def member_error_check(members)
       raise ScimRails::ExceptionHandler::InvalidMembers unless (members.is_a?(Array) && array_of_hashes?(members))

--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -52,7 +52,7 @@ module ScimRails
     def show
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
+      group = @company.public_send(ScimRails.config.scim_groups_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
 
       ScimRails.config.after_scim_response.call(group, "RETRIEVED") unless ScimRails.config.after_scim_response.nil?
 
@@ -62,7 +62,7 @@ module ScimRails
     def put_update
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
+      group = @company.public_send(ScimRails.config.scim_groups_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
 
       put_error_check
 
@@ -84,7 +84,7 @@ module ScimRails
     def patch_update
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
+      group = @company.public_send(ScimRails.config.scim_groups_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
 
       params["Operations"].each do |operation|
         case operation["op"]
@@ -107,7 +107,7 @@ module ScimRails
     def delete
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
+      group = @company.public_send(ScimRails.config.scim_groups_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
       group.delete
 
       ScimRails.config.after_scim_response.call(group, "DELETED") unless ScimRails.config.after_scim_response.nil?

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -1,8 +1,8 @@
 module ScimRails
   class ScimUsersController < ScimRails::ApplicationController
     def index
-      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
-
+      initial_callback_hook(request.params)
+      
       if params[:filter].present?
         query = ScimRails::ScimQueryParser.new(params[:filter])
 
@@ -25,13 +25,13 @@ module ScimRails
         total: users.count
       )
 
-      ScimRails.config.after_scim_response.call(users, "RETRIEVED") unless ScimRails.config.after_scim_response.nil?
+      final_callback_hook(users, "RETRIEVED")
 
       json_scim_response(object: users, counts: counts)
     end
 
     def create
-      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
+      initial_callback_hook(request.params)
 
       if ScimRails.config.scim_user_prevent_update_on_create
         user = @company.public_send(ScimRails.config.scim_users_scope).create!(permitted_params(params))
@@ -49,37 +49,37 @@ module ScimRails
       end
       update_status(user) unless put_active_param.nil?
 
-      ScimRails.config.after_scim_response.call(user, "CREATED") unless ScimRails.config.after_scim_response.nil?
+      final_callback_hook(user, "CREATED")
 
       json_scim_response(object: user, status: :created)
     end
 
     def show
-      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
+      initial_callback_hook(request.params)
 
-      user = @company.public_send(ScimRails.config.scim_users_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
+      user = user_find(params[:id])
 
-      ScimRails.config.after_scim_response.call(user, "RETRIEVED") unless ScimRails.config.after_scim_response.nil?
+      final_callback_hook(user, "RETRIEVED")
 
       json_scim_response(object: user)
     end
 
     def put_update
-      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
+      initial_callback_hook(request.params)
 
-      user = @company.public_send(ScimRails.config.scim_users_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
+      user = user_find(params[:id])
       update_status(user) unless put_active_param.nil?
       user.update!(permitted_params(params))
 
-      ScimRails.config.after_scim_response.call(user, "UPDATED") unless ScimRails.config.after_scim_response.nil?
+      final_callback_hook(user, "UPDATED")
 
       json_scim_response(object: user)
     end
 
     def patch_update
-      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
+      initial_callback_hook(request.params)
 
-      user = @company.public_send(ScimRails.config.scim_users_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
+      user = user_find(params[:id])
 
       params["Operations"].each do |operation|
         raise ScimRails::ExceptionHandler::UnsupportedPatchRequest if operation["op"] != "replace"
@@ -97,23 +97,27 @@ module ScimRails
         user.public_send(provision_method)
       end
 
-      ScimRails.config.after_scim_response.call(user, "UPDATED") unless ScimRails.config.after_scim_response.nil?
+      final_callback_hook(user, "UPDATED")
 
       json_scim_response(object: user)
     end
 
     def delete
-      ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
+      initial_callback_hook(request.params)
 
-      user = @company.public_send(ScimRails.config.scim_users_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
+      user = user_find(params[:id])
       user.delete
 
-      ScimRails.config.after_scim_response.call(user, "DELETED") unless ScimRails.config.after_scim_response.nil?
+      final_callback_hook(user, "DELETED")
 
       json_scim_response(object: nil, status: :no_content)
     end
 
     private
+
+    def user_find(term)
+      @company.public_send(ScimRails.config.scim_users_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{term}\""
+    end
 
     def permitted_params(parameters)
       ScimRails.config.mutable_user_attributes.each.with_object({}) do |attribute, hash|

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -57,7 +57,7 @@ module ScimRails
     def show
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
-      user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
+      user = @company.public_send(ScimRails.config.scim_users_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
 
       ScimRails.config.after_scim_response.call(user, "RETRIEVED") unless ScimRails.config.after_scim_response.nil?
 
@@ -67,7 +67,7 @@ module ScimRails
     def put_update
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
-      user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
+      user = @company.public_send(ScimRails.config.scim_users_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
       update_status(user) unless put_active_param.nil?
       user.update!(permitted_params(params))
 
@@ -79,7 +79,7 @@ module ScimRails
     def patch_update
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
-      user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
+      user = @company.public_send(ScimRails.config.scim_users_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
 
       params["Operations"].each do |operation|
         raise ScimRails::ExceptionHandler::UnsupportedPatchRequest if operation["op"] != "replace"
@@ -105,7 +105,7 @@ module ScimRails
     def delete
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
-      user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
+      user = @company.public_send(ScimRails.config.scim_users_scope).find_by! "#{ScimRails.config.canonical_reference} = \"#{params[:id]}\""
       user.delete
 
       ScimRails.config.after_scim_response.call(user, "DELETED") unless ScimRails.config.after_scim_response.nil?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,10 +6,10 @@ ScimRails::Engine.routes.draw do
   patch   'scim/v2/Users/:id',  action: :patch_update,  controller: 'scim_users'
   delete  'scim/v2/Users/:id',  action: :delete,        controller: 'scim_users'
 
-  get    'scim/v2/Groups',      action: :index,         controller: 'scim_groups'
-  post   'scim/v2/Groups',      action: :create,        controller: 'scim_groups'
-  get    'scim/v2/Groups/:id',  action: :show,          controller: 'scim_groups'
-  put    'scim/v2/Groups/:id',  action: :put_update,    controller: 'scim_groups'
-  patch  'scim/v2/Groups/:id',  action: :patch_update,  controller: 'scim_groups'
-  delete 'scim/v2/Groups/:id',  action: :delete,        controller: 'scim_groups'
+  get     'scim/v2/Groups',      action: :index,         controller: 'scim_groups'
+  post    'scim/v2/Groups',      action: :create,        controller: 'scim_groups'
+  get     'scim/v2/Groups/:id',  action: :show,          controller: 'scim_groups'
+  put     'scim/v2/Groups/:id',  action: :put_update,    controller: 'scim_groups'
+  patch   'scim/v2/Groups/:id',  action: :patch_update,  controller: 'scim_groups'
+  delete  'scim/v2/Groups/:id',  action: :delete,        controller: 'scim_groups'
 end

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -133,11 +133,12 @@ ScimRails.configure do |config|
   # each controller method. Will take the body of a given
   # request, i.e., the params, action, controller, etc.
   # This hook can be used for logging information to help
-  # with troubleshooting but can be left nil or commented
-  # out if it is not needed.
-  config.before_scim_response = lambda do |body|
-    print "BEFORE SCIM RESPONSE #{body}"
-  end
+  # with troubleshooting, if the following is something
+  # you need, uncomment the lambda below and feel free
+  # to customize if needed.
+  # config.before_scim_response = lambda do |body|
+  #   print "BEFORE SCIM RESPONSE #{body}"
+  # end
 
   # Callback hook that will be called at the end of each
   # controller method, given that the request was
@@ -145,9 +146,10 @@ ScimRails.configure do |config|
   # that was retrieved/create/updated/deleted its status
   # ("RETRIEVED", "CREATED", "UPDATED", "DELETED").
   # This hook can be used for logging information to help
-  # troubleshoot but can be left nil or commented out if
-  # it is not needed.
-  config.after_scim_response = lambda do |object, status|
-    print "#{object} #{status}"
-  end
+  # with troubleshooting, if the following is something
+  # you need, uncomment the lambda below and feel free to
+  # customize if needed.
+  # config.after_scim_response = lambda do |object, status|
+  #   print "#{object} #{status}"
+  # end
 end

--- a/lib/generators/scim_rails/templates/initializer.rb
+++ b/lib/generators/scim_rails/templates/initializer.rb
@@ -56,6 +56,10 @@ ScimRails.configure do |config|
   # Method called on user model to reprovision a user.
   config.user_reprovision_method = :unarchive!
 
+  # Unique identifier for model instances.  SHOULD be set
+  # to :id or :uuid
+  config.canonical_reference = :id
+
   # Hash of queryable attribtues on the user model. If
   # the attribute is not listed in this hash it cannot
   # be queried by this Gem. The structure of this hash

--- a/lib/scim_rails/config.rb
+++ b/lib/scim_rails/config.rb
@@ -33,6 +33,7 @@ module ScimRails
       :scim_group_prevent_update_on_create,
       :signing_secret,
       :signing_algorithm,
+      :canonical_reference,
       :user_attributes,
       :user_deprovision_method,
       :user_reprovision_method,

--- a/spec/dummy/app/models/group.rb
+++ b/spec/dummy/app/models/group.rb
@@ -1,6 +1,8 @@
 class Group < ApplicationRecord
   belongs_to :company
 
+  before_save :generate_uuid
+
   has_many :groups_users
   has_many :users, through: :groups_users
 
@@ -35,5 +37,11 @@ class Group < ApplicationRecord
   def unarchive!
     write_attribute(:archived_at, nil)
     save!
+  end
+
+  private
+
+  def generate_uuid
+    self.uuid ||= SecureRandom.uuid
   end
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   belongs_to :company
 
+  before_save :generate_uuid
+
   has_many :groups_users
   has_many :groups, through: :groups_users
 
@@ -36,5 +38,11 @@ class User < ApplicationRecord
   def unarchive!
     write_attribute(:archived_at, nil)
     save!
+  end
+
+  private
+
+  def generate_uuid
+    self.uuid ||= SecureRandom.uuid
   end
 end

--- a/spec/dummy/db/migrate/20181206184304_create_users.rb
+++ b/spec/dummy/db/migrate/20181206184304_create_users.rb
@@ -1,10 +1,11 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.string :first_name, null: false
       t.string :last_name, null: false
       t.string :email, null: false
       t.boolean :random_attribute, default: false
+      t.string :uuid, null: false
 
       t.integer :company_id
 

--- a/spec/dummy/db/migrate/20181206184313_create_companies.rb
+++ b/spec/dummy/db/migrate/20181206184313_create_companies.rb
@@ -1,4 +1,4 @@
-class CreateCompanies < ActiveRecord::Migration
+class CreateCompanies < ActiveRecord::Migration[4.2]
   def change
     create_table :companies do |t|
       t.string :name, null: false

--- a/spec/dummy/db/migrate/20200408161720_create_groups.rb
+++ b/spec/dummy/db/migrate/20200408161720_create_groups.rb
@@ -1,9 +1,10 @@
-class CreateGroups < ActiveRecord::Migration
+class CreateGroups < ActiveRecord::Migration[4.2]
   def change
     create_table :groups do |t|
       t.string :display_name, null: false
       t.string :email, null: false
       t.boolean :random_attribute, default: false
+      t.string :uuid, null: false
 
       t.integer :company_id
 

--- a/spec/dummy/db/migrate/20200408164220_create_groups_users.rb
+++ b/spec/dummy/db/migrate/20200408164220_create_groups_users.rb
@@ -1,4 +1,4 @@
-class CreateGroupsUsers < ActiveRecord::Migration
+class CreateGroupsUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :groups_users do |t|
       t.references :user, index: true, foreign_key: true

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,45 +10,46 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200408164220) do
+ActiveRecord::Schema.define(version: 2020_04_08_164220) do
 
   create_table "companies", force: :cascade do |t|
-    t.string   "name",       null: false
-    t.string   "subdomain",  null: false
-    t.string   "api_token",  null: false
+    t.string "name", null: false
+    t.string "subdomain", null: false
+    t.string "api_token", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "groups", force: :cascade do |t|
-    t.string   "display_name",                     null: false
-    t.string   "email",                            null: false
-    t.boolean  "random_attribute", default: false
-    t.integer  "company_id"
+    t.string "display_name", null: false
+    t.string "email", null: false
+    t.boolean "random_attribute", default: false
+    t.string "uuid", null: false
+    t.integer "company_id"
     t.datetime "archived_at"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-  end
-
-  create_table "groups_users", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "group_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  add_index "groups_users", ["group_id"], name: "index_groups_users_on_group_id"
-  add_index "groups_users", ["user_id"], name: "index_groups_users_on_user_id"
+  create_table "groups_users", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "group_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_groups_users_on_group_id"
+    t.index ["user_id"], name: "index_groups_users_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
-    t.string   "first_name",                       null: false
-    t.string   "last_name",                        null: false
-    t.string   "email",                            null: false
-    t.boolean  "random_attribute", default: false
-    t.integer  "company_id"
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.string "email", null: false
+    t.boolean "random_attribute", default: false
+    t.string "uuid", null: false
+    t.integer "company_id"
     t.datetime "archived_at"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -5,5 +5,7 @@ FactoryBot.define do
 
     sequence(:display_name) { |n| "#{Faker::Name.name}#{n}" }
     sequence(:email) { |n| "#{Faker::Internet.email}#{n}" }
+
+    uuid { SecureRandom.uuid }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,5 +5,7 @@ FactoryBot.define do
     sequence(:first_name) { |n| "#{Faker::Name.first_name}#{n}" }
     sequence(:last_name) { |n| "#{Faker::Name.last_name}#{n}" }
     sequence(:email) { |n| "#{n}@example.com" }
+
+    uuid { SecureRandom.uuid }
   end
 end

--- a/spec/support/scim_rails_config.rb
+++ b/spec/support/scim_rails_config.rb
@@ -99,11 +99,11 @@ ScimRails.configure do |config|
   }
 
   config.before_scim_response = lambda do |body|
-    print "BEFORE SCIM RESPONSE #{body}"
+
   end
 
   config.after_scim_response = lambda do |object, status|
-    print "#{object} #{status}"
+
   end
 
 end

--- a/spec/support/scim_rails_config.rb
+++ b/spec/support/scim_rails_config.rb
@@ -25,6 +25,8 @@ ScimRails.configure do |config|
   config.group_deprovision_method = :archive!
   config.group_reprovision_method = :unarchive!
 
+  config.canonical_reference = :id
+
   config.mutable_user_attributes = [
     :first_name,
     :last_name,

--- a/spec/support/scim_rails_config.rb
+++ b/spec/support/scim_rails_config.rb
@@ -25,7 +25,7 @@ ScimRails.configure do |config|
   config.group_deprovision_method = :archive!
   config.group_reprovision_method = :unarchive!
 
-  config.canonical_reference = :id
+  config.canonical_reference = :uuid
 
   config.mutable_user_attributes = [
     :first_name,
@@ -97,7 +97,7 @@ ScimRails.configure do |config|
   }
 
   config.group_member_schema = {
-    value: :id
+    value: config.canonical_reference
   }
 
   config.before_scim_response = lambda do |body|


### PR DESCRIPTION
## Why?

Prior to this PR, it was only possible to find SCIM Users/Groups by their `id`.  This PR adds more configuration options in the `canonical_reference` variable which allows for Users/Groups to be found by their `uuid` as well now, which would greatly improve security.

## What?

* Adds the `canonical_reference` variable to the configuration which must be set to either `:id` or `:uuid`
* Change dummy app to set the `canonical_reference` to `:uuid`, change tests accordingly as a result
* Add `uuid` to both User and Group models within the dummy app for testing purposes
* Small refactoring changes to tests
* Update initializer
