### PR TITLE
Fix PATCH method for Azure AD requests

### DIFF
--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -144,8 +144,8 @@ module ScimRails
         if index.zero?
           acc.store(key, value)
         else
-         key_path = keys.slice(0..(index - 1))
-         acc.dig(*key_path)&.store(key, value)
+          key_path = keys.slice(0..(index - 1))
+          acc.dig(*key_path)&.store(key, value)
         end
 
         acc

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -140,11 +140,11 @@ module ScimRails
 
       keys.each_with_index.reduce({}) do |acc, (key, index)|
         value = key == keys.last ? operation["value"] : {}
-        
+
         if index.zero?
           acc.store(key, value)
         else
-         key_path = keys.slice(0..(index - 1)) # Get the path except for the current key
+         key_path = keys.slice(0..(index - 1))
          acc.dig(*key_path)&.store(key, value)
         end
 

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -138,20 +138,18 @@ module ScimRails
     def process_path(operation)
       keys = operation["path"].split('.').map { |key| key.to_sym }
 
-      parsed_path = {}
-      key_chain = []
-
-      keys.each do |key|
-        if key_chain.empty?
-          parsed_path&.store(key, (key == keys.last) ? operation["value"] : {})
+      keys.each_with_index.reduce({}) do |acc, (key, index)|
+        value = key == keys.last ? operation["value"] : {}
+        
+        if index.zero?
+          acc.store(key, value)
         else
-          parsed_path.dig(*key_chain)&.store(key, (key == keys.last) ? operation["value"] : {})
+         key_path = keys.slice(0..(index - 1)) # Get the path except for the current key
+         acc.dig(*key_path)&.store(key, value)
         end
 
-        key_chain << key
+        acc
       end
-
-      parsed_path
     end
 
     def extract_path_params(operation)

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -116,6 +116,25 @@ module ScimRails
 
     private
 
+    # `process_path` is a method that parses the string in the "path"
+    # key of a PATCH operation. Together with the "value" key, it
+    # converts it into a Hash that can be used in the `permitted_params`
+    # method to help update the attributes of a User.
+    #
+    # Example: given the following operation:
+    #   operation = {
+    #     'op': 'Replace',
+    #     'path': 'name.givenName',
+    #     'value': 'Grayson'
+    #   }
+    # calling `process_path(operation)` will return the Hash:
+    #   {
+    #     name: {
+    #       givenName: 'Grayson'
+    #     }
+    #   }
+    # which can easily be processed by `permitted_params` which will get
+    # the attributes that will be updated by the PATCH request
     def process_path(operation)
       keys = operation["path"].split('.').map { |key| key.to_sym }
 

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -650,6 +650,35 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
           expect(company_user.last_name).to eq(final_family_name)
         end
       end
+
+      context "with azure requests" do
+        let(:new_test_attribute) { Faker::Games::Pokemon.move }
+        let(:new_name) { Faker::Name.name }
+
+        it "processes path field and updates attribute" do
+          patch :patch_update, params: azure_patch_params(id: 1, path: "testAttribute", value: new_test_attribute)
+
+          expect(company_user.test_attribute).to eq(new_test_attribute)
+        end
+
+        it "processes path with periods and updates attribute" do
+          patch :patch_update, params: azure_patch_params(id: 1, path: "name.givenName", value: new_name)
+
+          expect(company_user.first_name).to eq(new_name)
+        end
+
+        it "processes path and activates user" do
+          patch :patch_update, params: azure_patch_params(id: 1, path: "active", value: true)
+
+          expect(company_user.archived?).to eq(false)
+        end
+
+        it "processes path and deactivates user" do
+          patch :patch_update, params: azure_patch_params(id: 1, path: "active", value: false)
+
+          expect(company_user.archived?).to eq(true)
+        end
+      end
     end
   end
 
@@ -721,6 +750,19 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
           value: {
             active: active
           }
+        }
+      ]
+    }
+  end
+
+  def azure_patch_params(id:, path:, value:)
+    {
+      id: id,
+      Operations: [
+        {
+          op: "Replace",
+          path: path,
+          value: value
         }
       ]
     }

--- a/spec/dummy/db/migrate/20181206184304_create_users.rb
+++ b/spec/dummy/db/migrate/20181206184304_create_users.rb
@@ -5,6 +5,7 @@ class CreateUsers < ActiveRecord::Migration
       t.string :last_name, null: false
       t.string :email, null: false
       t.boolean :random_attribute, default: false
+      t.string :test_attribute
 
       t.integer :company_id
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -36,16 +35,16 @@ ActiveRecord::Schema.define(version: 20200408164220) do
     t.integer  "group_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_groups_users_on_group_id"
+    t.index ["user_id"], name: "index_groups_users_on_user_id"
   end
-
-  add_index "groups_users", ["group_id"], name: "index_groups_users_on_group_id"
-  add_index "groups_users", ["user_id"], name: "index_groups_users_on_user_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "first_name",                       null: false
     t.string   "last_name",                        null: false
     t.string   "email",                            null: false
     t.boolean  "random_attribute", default: false
+    t.string   "test_attribute"
     t.integer  "company_id"
     t.datetime "archived_at"
     t.datetime "created_at",                       null: false

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,5 +5,7 @@ FactoryBot.define do
     sequence(:first_name) { |n| "#{Faker::Name.first_name}#{n}" }
     sequence(:last_name) { |n| "#{Faker::Name.last_name}#{n}" }
     sequence(:email) { |n| "#{n}@example.com" }
+    
+    test_attribute { Faker::Games::Pokemon.name }
   end
 end

--- a/spec/support/scim_rails_config.rb
+++ b/spec/support/scim_rails_config.rb
@@ -28,26 +28,28 @@ ScimRails.configure do |config|
   config.mutable_user_attributes = [
     :first_name,
     :last_name,
-    :email
+    :email,
+    :test_attribute,
   ]
 
   config.mutable_group_attributes = [
     :display_name,
     :email,
-    :members
+    :members,
   ]
 
   config.queryable_user_attributes = {
     userName: :email,
     givenName: :first_name,
     familyName: :last_name,
-    email: :email
+    email: :email,
+    testAttribute: :test_attribute,
   }
 
   config.queryable_group_attributes = {
     userName: :display_name,
     displayName: :display_name,
-    email: :email
+    email: :email,
   }
 
   config.mutable_user_attributes_schema = {
@@ -59,13 +61,14 @@ ScimRails.configure do |config|
       {
         value: :email
       }
-    ]
+    ],
+    testAttribute: :test_attribute,
   }
 
   config.mutable_group_attributes_schema = {
     displayName: :display_name,
     email: :email,
-    members: :members
+    members: :members,
   }
 
   config.user_schema = {
@@ -81,7 +84,8 @@ ScimRails.configure do |config|
         value: :email
       },
     ],
-    active: :unarchived?
+    testAttribute: :test_attribute,
+    active: :unarchived?,
   }
 
   config.group_schema = {
@@ -91,19 +95,19 @@ ScimRails.configure do |config|
     displayName: :display_name,
     email: :email,
     members: [],
-    active: :unarchived?
+    active: :unarchived?,
   }
 
   config.group_member_schema = {
-    value: :id
+    value: :id,
   }
 
-  config.before_scim_response = lambda do |body|
-    print "BEFORE SCIM RESPONSE #{body}"
-  end
+  # config.before_scim_response = lambda do |body|
+  #   print "BEFORE SCIM RESPONSE #{body}"
+  # end
 
-  config.after_scim_response = lambda do |object, status|
-    print "#{object} #{status}"
-  end
+  # config.after_scim_response = lambda do |object, status|
+  #   print "#{object} #{status}"
+  # end
 
 end


### PR DESCRIPTION
## Why?

Azure AD sends requests which are formatted different from how Okta sends requests, for example with PATCH requests.  The params for a typical PATCH request from Okta would look like this:
```json
{
  "Operations": [
    {
      "op": "replace",
      "value": {
        "active": true
      }
    }
  ]
}
```
while the params for a typical PATCH request from Azure AD may look something like this:
```json
{
  "Operations": [
    {
      "op": "Replace",
      "path": "name.givenName",
      "value": "Min Min"
    }
  ]
}
``` 
Because this gem is designed for Okta requests, many of the requests from Azure AD will fail.  This PR attempts to add support such that requests such as these will no longer break.

## What?

The most notable difference between the requests is the addition of the "path" key to the JSON payload.  This PR attempts to make it possible to parse these path strings such that they will be recognized by the gem when Azure AD sends requests to the server.