### PR TITLE
[#530651460] Add more support for Azure AD requests

### DIFF
--- a/app/controllers/scim_rails/application_controller.rb
+++ b/app/controllers/scim_rails/application_controller.rb
@@ -39,7 +39,7 @@ module ScimRails
     # Shared stuff...
 
     def contains_square_brackets?(string)
-      !(string =~ /\[.*\]/).nil?
+      (string =~ /\[.*\]/).is_a?(Numeric)
     end
 
     def before_square_brackets(string)

--- a/app/controllers/scim_rails/application_controller.rb
+++ b/app/controllers/scim_rails/application_controller.rb
@@ -38,6 +38,10 @@ module ScimRails
     
     # Shared stuff...
 
+    def contains_square_brackets?(string)
+      !(string =~ /\[.*\]/).nil?
+    end
+
     def before_square_brackets(string)
       string.match(/([^\[]+)/).to_s
     end

--- a/app/controllers/scim_rails/application_controller.rb
+++ b/app/controllers/scim_rails/application_controller.rb
@@ -42,19 +42,19 @@ module ScimRails
       (string =~ /\[.*\]/).is_a?(Numeric)
     end
 
-    def before_square_brackets(string)
+    def extract_from_before_square_brackets(string)
       string.match(/([^\[]+)/).to_s
     end
 
-    def inside_square_brackets(string)
+    def extract_from_inside_square_brackets(string)
       string.match(/(?<=\[).+?(?=\])/).to_s
     end
 
-    def after_square_brackets(string)
+    def extract_from_after_square_brackets(string)
       string.match(/(?<=\]).*/).to_s
     end
 
-    def inside_quotations(string)
+    def extract_from_inside_quotations(string)
       string.match(/(?<=")[^"]+(?=")/).to_s
     end
 
@@ -129,13 +129,13 @@ module ScimRails
     def process_filter_path(operation)
       path_string = operation["path"]
 
-      pre_bracket_path = before_square_brackets(path_string)
-      filter = inside_square_brackets(path_string)
+      pre_bracket_path = extract_from_before_square_brackets(path_string)
+      filter = extract_from_inside_square_brackets(path_string)
 
       args = filter.split(' ')
 
       key = args[0]
-      value = inside_quotations(args[2])
+      value = extract_from_inside_quotations(args[2])
 
       inner_hash = {}
       inner_hash[key] = value
@@ -174,12 +174,12 @@ module ScimRails
       merge_params = {}
 
       ScimRails.config.scim_attribute_type_mappings.each do |mapping_key, mapping_value|
-        if schema_hash.key?(mapping_key)
-          schema_hash[mapping_key].each do |attribute|
-            if mapping_value.key?(attribute["type"])
-              merge_params[mapping_value[attribute["type"]]] = attribute["value"]
-            end
-          end
+        next unless schema_hash.key?(mapping_key)
+
+        schema_hash[mapping_key].each do |attribute|
+          next unless mapping_value.key?(attribute["type"])
+
+          merge_params[mapping_value[attribute["type"]]] = attribute["value"]
         end
       end
 

--- a/app/controllers/scim_rails/application_controller.rb
+++ b/app/controllers/scim_rails/application_controller.rb
@@ -146,6 +146,45 @@ module ScimRails
 
       full_hash
     end
+
+    # `multi_attr_type_to_value` is a method that takes a request body
+    # and compares it to the `scim_attribute_type_mappings`, to return
+    # a hash which may contain attributes of the User model
+    #
+    # Example: given the following:
+    #   schema_hash = {
+    #     "emails": [
+    #       {
+    #         "type": "work",
+    #         "value": "work@example.com"
+    #       }
+    #     ]
+    #   }
+    # and `scim_attribute_type_mappings` being defined as:
+    #   {
+    #     "emails" => {
+    #       "work" => :email
+    #     }
+    #   }
+    # means calling `multi_attr_type_to_value` will return the Hash
+    #   {
+    #     email: "work@example.com"
+    #   }
+    def multi_attr_type_to_value(schema_hash)
+      merge_params = {}
+
+      ScimRails.config.scim_attribute_type_mappings.each do |mapping_key, mapping_value|
+        if schema_hash.key?(mapping_key)
+          schema_hash[mapping_key].each do |attribute|
+            if mapping_value.key?(attribute["type"])
+              merge_params[mapping_value[attribute["type"]]] = attribute["value"]
+            end
+          end
+        end
+      end
+
+      merge_params
+    end
     
     # `path_for` is a recursive method used to find the "path" for
     # `.dig` to take when looking for a given attribute in the

--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -211,9 +211,9 @@ module ScimRails
         return
       end
 
-      pre_bracket_path = before_square_brackets(path_string)
-      filter = inside_square_brackets(path_string)
-      path_suffix = after_square_brackets(path_string)
+      pre_bracket_path = extract_from_before_square_brackets(path_string)
+      filter = extract_from_inside_square_brackets(path_string)
+      path_suffix = extract_from_after_square_brackets(path_string)
 
       raise ScimRails::ExceptionHandler::BadPatchPath unless (pre_bracket_path == "members" && path_suffix == "")
 

--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -211,17 +211,9 @@ module ScimRails
         return
       end
 
-      # Everything before square brackets
-      # E.g. given a path_string of "prefix[inner]suffix", pre_bracket_path will be "prefix"
-      pre_bracket_path = path_string.match(/([^\[]+)/).to_s
-
-      # Everything within the square brackets
-      # E.g. using path_string from the above example, filter will be "inner"
-      filter = path_string.match(/(?<=\[).+?(?=\])/).to_s
-
-      # Everything after the square brackets (this should be empty)
-      # E.g. using path_string from the above example, path_suffix will be "suffix"
-      path_suffix = path_string.match(/(?<=\]).*/).to_s
+      pre_bracket_path = before_square_brackets(path_string)
+      filter = inside_square_brackets(path_string)
+      path_suffix = after_square_brackets(path_string)
 
       raise ScimRails::ExceptionHandler::BadPatchPath unless (pre_bracket_path == "members" && path_suffix == "")
 

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -123,22 +123,6 @@ module ScimRails
       schema_hash = contains_square_brackets?(operation["path"]) ? multi_attr_type_to_value(process_filter_path(operation)) : {}
     end
 
-    def multi_attr_type_to_value(schema_hash)
-      merge_params = {}
-
-      ScimRails.config.scim_attribute_type_mappings.each do |mapping_key, mapping_value|
-        if schema_hash.key?(mapping_key)
-          schema_hash[mapping_key].each do |attribute|
-            if mapping_value.key?(attribute["type"])
-              merge_params[mapping_value[attribute["type"]]] = attribute["value"]
-            end
-          end
-        end
-      end
-
-      merge_params
-    end
-
     def permitted_params(parameters)
       ScimRails.config.mutable_user_attributes.each.with_object({}) do |attribute, hash|
         hash[attribute] = parameters.dig(*path_for(attribute))

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -82,7 +82,7 @@ module ScimRails
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
 
       params["Operations"].each do |operation|
-        raise ScimRails::ExceptionHandler::UnsupportedPatchRequest if operation["op"].downcase != "replace"
+        raise ScimRails::ExceptionHandler::UnsupportedPatchRequest unless ["replace", "add", "remove"].include?(operation["op"].downcase)
 
         path_params = extract_path_params(operation)
         changed_attributes = permitted_params(path_params || operation["value"])

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -33,19 +33,20 @@ module ScimRails
     def create
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
+      user_params = permitted_params(params).merge(multi_attr_type_to_value(params))
+
       if ScimRails.config.scim_user_prevent_update_on_create
-        user = @company.public_send(ScimRails.config.scim_users_scope).create!(permitted_params(params))
+        user = @company.public_send(ScimRails.config.scim_users_scope).create!(user_params)
       else
         username_key = ScimRails.config.queryable_user_attributes[:userName]
 
         find_by_username = Hash.new
-        permitted_user_params = permitted_params(params)
 
-        find_by_username[username_key] = permitted_user_params[username_key]
+        find_by_username[username_key] = user_params[username_key]
         user = @company
           .public_send(ScimRails.config.scim_users_scope)
           .find_or_create_by(find_by_username)
-        user.update!(permitted_user_params)
+        user.update!(user_params)
       end
       update_status(user) unless put_active_param.nil?
 
@@ -69,7 +70,9 @@ module ScimRails
 
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
       update_status(user) unless put_active_param.nil?
-      user.update!(permitted_params(params))
+
+      user_params = permitted_params(params).merge(multi_attr_type_to_value(params))
+      user.update!(user_params)
 
       ScimRails.config.after_scim_response.call(user, "UPDATED") unless ScimRails.config.after_scim_response.nil?
 
@@ -85,7 +88,7 @@ module ScimRails
         raise ScimRails::ExceptionHandler::UnsupportedPatchRequest unless ["replace", "add", "remove"].include?(operation["op"].downcase)
 
         path_params = extract_path_params(operation)
-        changed_attributes = permitted_params(path_params || operation["value"])
+        changed_attributes = permitted_params(path_params || operation["value"]).merge(get_multi_value_attrs(operation))
 
         user.update!(changed_attributes.compact)
 
@@ -115,6 +118,26 @@ module ScimRails
     end
 
     private
+
+    def get_multi_value_attrs(operation)
+      schema_hash = contains_square_brackets?(operation["path"]) ? multi_attr_type_to_value(process_filter_path(operation)) : {}
+    end
+
+    def multi_attr_type_to_value(schema_hash)
+      merge_params = {}
+
+      ScimRails.config.scim_attribute_type_mappings.each do |mapping_key, mapping_value|
+        if schema_hash.key?(mapping_key)
+          schema_hash[mapping_key].each do |attribute|
+            if mapping_value.key?(attribute["type"])
+              merge_params[mapping_value[attribute["type"]]] = attribute["value"]
+            end
+          end
+        end
+      end
+
+      merge_params
+    end
 
     def permitted_params(parameters)
       ScimRails.config.mutable_user_attributes.each.with_object({}) do |attribute, hash|

--- a/lib/scim_rails/config.rb
+++ b/lib/scim_rails/config.rb
@@ -46,6 +46,7 @@ module ScimRails
       :custom_group_attributes,
       :before_scim_response,
       :after_scim_response,
+      :scim_attribute_type_mappings,
 
     def initialize
       @basic_auth_model = "Company"

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -526,12 +526,12 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
         expect(response.status).to eq 404
       end
 
-      it "returns 422 error for an op that isn't 'replace'" do
+      it "returns 422 error for an invalid op" do
         patch :patch_update, params: {
           id: 1,
           Operations: [
             {
-              op: "remove"
+              op: "hamburger"
             }
           ]
         }

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -707,6 +707,26 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
               end
             end
           end
+
+          context "with path related to email array" do
+            context "when email is of 'work' type" do
+              let(:patch_path) { "emails[type eq \"work\"].value" }
+              let(:patch_value) { Faker::Internet.email }
+
+              it "updates :email attribute" do
+                expect(company_user.email).to eq(patch_value)
+              end
+            end
+
+            context "when email is of 'other' type" do
+              let(:patch_path) { "emails[type eq \"other\"].value" }
+              let(:patch_value) { Faker::Internet.email }
+
+              it "updates :alternate_email attribute" do
+                expect(company_user.alternate_email).to eq(patch_value)
+              end
+            end
+          end
         end
       end
     end

--- a/spec/dummy/db/migrate/20181206184304_create_users.rb
+++ b/spec/dummy/db/migrate/20181206184304_create_users.rb
@@ -1,9 +1,12 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
       t.string :first_name, null: false
       t.string :last_name, null: false
+
       t.string :email, null: false
+      t.string :alternate_email
+
       t.boolean :random_attribute, default: false
       t.string :test_attribute
 

--- a/spec/dummy/db/migrate/20181206184313_create_companies.rb
+++ b/spec/dummy/db/migrate/20181206184313_create_companies.rb
@@ -1,4 +1,4 @@
-class CreateCompanies < ActiveRecord::Migration
+class CreateCompanies < ActiveRecord::Migration[5.2]
   def change
     create_table :companies do |t|
       t.string :name, null: false

--- a/spec/dummy/db/migrate/20200408161720_create_groups.rb
+++ b/spec/dummy/db/migrate/20200408161720_create_groups.rb
@@ -1,4 +1,4 @@
-class CreateGroups < ActiveRecord::Migration
+class CreateGroups < ActiveRecord::Migration[5.2]
   def change
     create_table :groups do |t|
       t.string :display_name, null: false

--- a/spec/dummy/db/migrate/20200408164220_create_groups_users.rb
+++ b/spec/dummy/db/migrate/20200408164220_create_groups_users.rb
@@ -1,4 +1,4 @@
-class CreateGroupsUsers < ActiveRecord::Migration
+class CreateGroupsUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :groups_users do |t|
       t.references :user, index: true, foreign_key: true

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,29 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200408164220) do
+ActiveRecord::Schema.define(version: 2020_04_08_164220) do
 
   create_table "companies", force: :cascade do |t|
-    t.string   "name",       null: false
-    t.string   "subdomain",  null: false
-    t.string   "api_token",  null: false
+    t.string "name", null: false
+    t.string "subdomain", null: false
+    t.string "api_token", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "groups", force: :cascade do |t|
-    t.string   "display_name",                     null: false
-    t.string   "email",                            null: false
-    t.boolean  "random_attribute", default: false
-    t.integer  "company_id"
+    t.string "display_name", null: false
+    t.string "email", null: false
+    t.boolean "random_attribute", default: false
+    t.integer "company_id"
     t.datetime "archived_at"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "groups_users", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "group_id"
+    t.integer "user_id"
+    t.integer "group_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["group_id"], name: "index_groups_users_on_group_id"
@@ -40,15 +40,16 @@ ActiveRecord::Schema.define(version: 20200408164220) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "first_name",                       null: false
-    t.string   "last_name",                        null: false
-    t.string   "email",                            null: false
-    t.boolean  "random_attribute", default: false
-    t.string   "test_attribute"
-    t.integer  "company_id"
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.string "email", null: false
+    t.string "alternate_email"
+    t.boolean "random_attribute", default: false
+    t.string "test_attribute"
+    t.integer "company_id"
     t.datetime "archived_at"
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     sequence(:email) { |n| "#{n}@example.com" }
     
     test_attribute { Faker::Games::Pokemon.name }
+    alternate_email { Faker::Internet.email }
   end
 end

--- a/spec/support/scim_rails_config.rb
+++ b/spec/support/scim_rails_config.rb
@@ -110,4 +110,11 @@ ScimRails.configure do |config|
   #   print "#{object} #{status}"
   # end
 
+  config.scim_attribute_type_mappings = {
+    "emails" => {
+      "work" => :email,
+      "other" => :alternate_email,
+    },
+  }
+
 end


### PR DESCRIPTION
## Why?

This is a continuation of the upgrades to this gem to add full support for Azure AD with SCIM.  The main motivation for these changes came from request params to our Users endpoint like these:

```json=
{
  "op": "Add",
  "path": "emails[type eq \"work\"].value",
  "value": "work@example.com"
}
```

which would not be able to be processed by this gem causing errors to arise.  Note that these kinds of requests are extremely common in Azure AD.  My first thought was to convert the request params into something like this:

```ruby=
{
  "emails": [
    {
      "type": "work",
      "value": "work@example.com"
    }
  ]
}
```

so we could use it in `permitted_params` but that only made me realize another problem.

This gem completely ignores the "type" key, which is so commonly used in Azure AD requests.  So, I needed to fix this as well, due to the fact that this issue would cause a lot of unexpected behaviour such as the wrong attributes of a User being modified.

Note that there were workarounds in Okta, which allowed me to put off this issue for the time being.  However as we transition to make this gem usable with Azure AD as well, this issue is unavoidable.

## What?

* Create `process_filter_path` which is a method to convert various Azure requests into something we can use
* Create a new config variable: `scim_attribute_type_mappings` which is used to map the aforementioned "type" key values onto User attributes
* Modify the `post`, `put`, and `patch` methods of the User controller to account for these mappings when updating or creating a User
* Add tests, change User schema for dummy app to better test changes made in this PR