### PR TITLE
Refactor controllers

### DIFF
--- a/app/controllers/scim_rails/application_controller.rb
+++ b/app/controllers/scim_rails/application_controller.rb
@@ -194,7 +194,7 @@ module ScimRails
       else
         mutable_attributes = ScimRails.config.mutable_group_attributes
         mutable_attributes_schema = ScimRails.config.mutable_group_attributes_schema
-        custom_attributes = ScimRails.config.custom_user_attributes
+        custom_attributes = ScimRails.config.custom_group_attributes
       end
 
       mutable_attributes.each.with_object({}) do |attribute, hash|

--- a/app/controllers/scim_rails/application_controller.rb
+++ b/app/controllers/scim_rails/application_controller.rb
@@ -187,9 +187,15 @@ module ScimRails
     end
 
     def permitted_params(parameters, object_type)
-      mutable_attributes = (object_type == "User") ? ScimRails.config.mutable_user_attributes : ScimRails.config.mutable_group_attributes
-      mutable_attributes_schema = (object_type == "User") ? ScimRails.config.mutable_user_attributes_schema : ScimRails.config.mutable_group_attributes_schema
-      custom_attributes = (object_type == "User") ? ScimRails.config.custom_user_attributes : ScimRails.config.custom_user_attributes
+      if object_type == "User"
+        mutable_attributes = ScimRails.config.mutable_user_attributes
+        mutable_attributes_schema = ScimRails.config.mutable_user_attributes_schema
+        custom_attributes = ScimRails.config.custom_user_attributes
+      else
+        mutable_attributes = ScimRails.config.mutable_group_attributes
+        mutable_attributes_schema = ScimRails.config.mutable_group_attributes_schema
+        custom_attributes = ScimRails.config.custom_user_attributes
+      end
 
       mutable_attributes.each.with_object({}) do |attribute, hash|
         hash[attribute] = parameters.dig(*path_for(attribute, mutable_attributes_schema))
@@ -224,9 +230,14 @@ module ScimRails
     end
 
     def update_status(object)
-      reprovision_method = object.is_a?(ScimRails.config.scim_users_model) ? ScimRails.config.user_reprovision_method : ScimRails.config.group_reprovision_method
-      deprovision_method = object.is_a?(ScimRails.config.scim_users_model) ? ScimRails.config.user_deprovision_method : ScimRails.config.group_deprovision_method
-      
+      if object.is_a?(ScimRails.config.scim_users_model)
+        reprovision_method = ScimRails.config.user_reprovision_method
+        deprovision_method = ScimRails.config.user_deprovision_method
+      else
+        reprovision_method = ScimRails.config.group_reprovision_method
+        deprovision_method = ScimRails.config.group_deprovision_method
+      end
+
       object.public_send(reprovision_method) if active?
       object.public_send(deprovision_method) unless active?
     end

--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -130,14 +130,7 @@ module ScimRails
         
       return if params[:active].nil?
 
-      case params[:active]
-      when true, "true", 1
-        
-      when false, "false", 0
-        
-      else
-        raise ScimRails::ExceptionHandler::InvalidActiveParam
-      end
+      raise ScimRails::ExceptionHandler::InvalidActiveParam unless [true, "true", 1, false, "false", 0].include?(params[:active])
     end
 
     def add_members(group, member_ids)

--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -28,10 +28,10 @@ module ScimRails
     def create
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
-      group_attributes = permitted_params(params, "Group")
+      group_attributes = permitted_params(params, "Group").except(:members)
 
       if ScimRails.config.scim_group_prevent_update_on_create
-        group = @company.public_send(ScimRails.config.scim_groups_scope).create!(group_attributes.except(:members))
+        group = @company.public_send(ScimRails.config.scim_groups_scope).create!(group_attributes)
       else
         username_key = ScimRails.config.queryable_group_attributes[:userName]
         find_by_username = {}
@@ -39,7 +39,7 @@ module ScimRails
         group = @company
           .public_send(ScimRails.config.scim_groups_scope)
           .find_or_create_by(find_by_username)
-        group.update!(group_attributes.except(:members))
+        group.update!(group_attributes)
       end
 
       update_status(group) unless params[:active].nil?

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -73,7 +73,7 @@ module ScimRails
       user_params = permitted_params(params, "User").merge(multi_attr_type_to_value(params))
       user.update!(user_params)
 
-      update_status(user) unless put_active_param.nil?
+      update_status(user) unless params[:active].nil?
 
       ScimRails.config.after_scim_response.call(user, "UPDATED") unless ScimRails.config.after_scim_response.nil?
 

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -33,7 +33,7 @@ module ScimRails
     def create
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
-      user_params = permitted_params(params).merge(multi_attr_type_to_value(params))
+      user_params = permitted_params(params, "User").merge(multi_attr_type_to_value(params))
 
       if ScimRails.config.scim_user_prevent_update_on_create
         user = @company.public_send(ScimRails.config.scim_users_scope).create!(user_params)
@@ -48,7 +48,7 @@ module ScimRails
           .find_or_create_by(find_by_username)
         user.update!(user_params)
       end
-      update_status(user) unless put_active_param.nil?
+      update_status(user) unless params[:active].nil?
 
       ScimRails.config.after_scim_response.call(user, "CREATED") unless ScimRails.config.after_scim_response.nil?
 
@@ -69,9 +69,9 @@ module ScimRails
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
       user = @company.public_send(ScimRails.config.scim_users_scope).find(params[:id])
-      update_status(user) unless put_active_param.nil?
+      update_status(user) unless params[:active].nil?
 
-      user_params = permitted_params(params).merge(multi_attr_type_to_value(params))
+      user_params = permitted_params(params, "User").merge(multi_attr_type_to_value(params))
       user.update!(user_params)
 
       ScimRails.config.after_scim_response.call(user, "UPDATED") unless ScimRails.config.after_scim_response.nil?
@@ -88,7 +88,7 @@ module ScimRails
         raise ScimRails::ExceptionHandler::UnsupportedPatchRequest unless ["replace", "add", "remove"].include?(operation["op"].downcase)
 
         path_params = extract_path_params(operation)
-        changed_attributes = permitted_params(path_params || operation["value"]).merge(get_multi_value_attrs(operation))
+        changed_attributes = permitted_params(path_params || operation["value"], "User").merge(get_multi_value_attrs(operation))
 
         user.update!(changed_attributes.compact)
 
@@ -121,45 +121,6 @@ module ScimRails
 
     def get_multi_value_attrs(operation)
       schema_hash = contains_square_brackets?(operation["path"]) ? multi_attr_type_to_value(process_filter_path(operation)) : {}
-    end
-
-    def permitted_params(parameters)
-      ScimRails.config.mutable_user_attributes.each.with_object({}) do |attribute, hash|
-        hash[attribute] = parameters.dig(*path_for(attribute))
-      end.merge(ScimRails.config.custom_user_attributes)
-    end
-
-    def update_status(user)
-      user.public_send(ScimRails.config.user_reprovision_method) if active?
-      user.public_send(ScimRails.config.user_deprovision_method) unless active?
-    end
-
-    def patch_status(active_param)
-      case active_param
-      when true, "true", 1
-        true
-      when false, "false", 0
-        false
-      else
-        nil
-      end
-    end
-
-    def active?
-      active = put_active_param
-
-      case active
-      when true, "true", 1
-        true
-      when false, "false", 0
-        false
-      else
-        raise ActiveRecord::RecordInvalid
-      end
-    end
-
-    def put_active_param
-      params[:active]
     end
   end
 end


### PR DESCRIPTION
## Why?

In both the user and group controllers in this gem, there is an abundance of repetitive and redundant code which can lead to confusion when looking at the files

## What?

- Put any methods which are duplicated across controllers (e.g. having `permitted_params` in the users controller and `permitted_group_params` in the groups controller even though they functionally do the same thing) into the application controller
- Remove any code or methods which are no longer used