### PR TITLE
[SST-15759] convert member list ids to integers

### DIFF
--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -164,9 +164,11 @@ module ScimRails
     end
 
     def add_members(group, member_ids)
+      member_ids = member_ids.map{ |id| id.to_i }
+
       new_member_ids = member_ids - group.public_send(ScimRails.config.scim_group_member_scope).pluck(:id)
       new_members = @company.public_send(ScimRails.config.scim_users_scope).find(new_member_ids)
-      
+
       group.public_send(ScimRails.config.scim_group_member_scope) << new_members if new_members.present?
     end
 

--- a/spec/controllers/scim_rails/scim_groups_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_groups_controller_spec.rb
@@ -686,6 +686,34 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
                   expect(response.status).to eq(404)
                 end
               end
+
+              context "with repeated member additions" do
+                let(:patch_value) { [ { value: new_user.id } ] }
+
+                let(:alt_patch_value) { [ { value: new_user.id.to_s } ] }
+                let(:alt_params) do
+                  {
+                    id: patch_id,
+                    Operations: [
+                      {
+                        op: patch_operation,
+                        path: patch_path,
+                        value: alt_patch_value
+                      }
+                    ]
+                  }
+                end
+
+                let(:alt_patch) { patch :patch_update, params: alt_params, as: :json }
+
+                it "only adds member to group once" do
+                  expect(response.status).to eq(200)
+                  expect(updated_user_list.length).to eq(user_list_length + 1)
+                  expect(updated_user_ids).to include(new_user.id)
+
+                  expect{ alt_patch }.to_not change{ updated_user_list.length }
+                end
+              end
             end
   
             context "when path not set to 'members'" do


### PR DESCRIPTION
## Why?

The current procedure for adding members to a group is wrong.

What it did prior to this PR is that it would create an array containing the IDs of the members to be added to the group, and then the IDs of members already belonging to the group would be filtered out of that array.  The line of code that accomplishes essentially does `new_member_ids = new_member_ids - existing_member_ids`.  The problem is that at the moment, `new_member_ids` can be an array of either ints or strings, while `existing_member_ids` is always an array of ints.  In the event that `new_member_ids` is an array of strings, the members may be still be added to the group even though they should be filtered out.

## What?

Convert `new_member_ids` to an array of ints before filtering, such that existing IDs will filtered out regardless of the type.