### PR TITLE
handle SCIM schema extensions on patch_update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scim_rails (0.3.1)
+    scim_rails (0.3.2)
       jwt (>= 1.5, < 3.0)
       rails (~> 5.0)
 

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -93,7 +93,7 @@ module ScimRails
         path_params = extract_path_params(operation)
         changed_attributes = permitted_params(path_params || operation["value"], "User").merge(get_multi_value_attrs(operation))
 
-        user.update!(changed_attributes.compact)
+        user.assign_attributes(changed_attributes.compact)
 
         active_param = extract_active_param(operation, path_params)
         status = patch_status(active_param)
@@ -103,6 +103,8 @@ module ScimRails
         provision_method = status ? ScimRails.config.user_reprovision_method : ScimRails.config.user_deprovision_method
         user.public_send(provision_method)
       end
+
+      user.save!
 
       ScimRails.config.after_scim_response.call(user, "UPDATED") unless ScimRails.config.after_scim_response.nil?
 

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,3 +1,3 @@
 module ScimRails
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -800,6 +800,15 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
               end
             end
           end
+
+          context "with urn:ietf:params:scim:schemas:extension:enterprise:2.0:User path" do
+            let(:patch_path) { "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department" }
+            let(:patch_value) { Faker::Commerce.department }
+
+            it "updates :department attribute" do
+              expect(company_user.department).to eq(patch_value)
+            end
+          end
         end
 
         context "when add operation" do

--- a/spec/dummy/db/migrate/20210819053930_add_depaartment_to_user.rb
+++ b/spec/dummy/db/migrate/20210819053930_add_depaartment_to_user.rb
@@ -1,0 +1,5 @@
+class AddDepaartmentToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :department, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_31_202326) do
+ActiveRecord::Schema.define(version: 2021_08_19_053930) do
 
   create_table "companies", force: :cascade do |t|
     t.string "name", null: false
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 2021_03_31_202326) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "scoped_attribute", default: true
+    t.string "department"
   end
 
 end

--- a/spec/support/scim_rails_config.rb
+++ b/spec/support/scim_rails_config.rb
@@ -30,6 +30,7 @@ ScimRails.configure do |config|
     :last_name,
     :email,
     :test_attribute,
+    :department
   ]
 
   config.mutable_group_attributes = [
@@ -63,6 +64,9 @@ ScimRails.configure do |config|
       }
     ],
     testAttribute: :test_attribute,
+    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+      department: :department,
+    },
   }
 
   config.mutable_group_attributes_schema = {


### PR DESCRIPTION
## Why?

When the `ScimUsersController#patch_update` endpoint was hit and had an `operation` with a `path` value that used SCIM's schema extensions `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`, it would not parse this parameter properly resulting in the underlying attribute never getting updated.

## What?

Added a handler for scenarios where we receive a paramater that is part of SCIM's schema extensions. It isn't pretty but it gets the job done. 
Also refactored a case statement that didn't handle when the operation sent the `active` attribute as `"True"` or `"False"`. Simplified it to cast it as a boolean to handle that scenario and get rid of the case statement


