### PR TITLE
[feature-kube-at1-154] Fix bug where company and department are not being updated

### DIFF
--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -155,7 +155,15 @@ module ScimRails
     # {"a.b.c"=>"v", "b.c.d"=>"c"} ---> {:a=>{:b=>{:c=>"v"}}, :b=>{:c=>{:d=>"c"}}}
     def flat_keys_to_nested(hash)
       hash.each_with_object({}) do |(key,value), all|
-        key_parts = key.split('.').map(&:to_sym)
+        key_parts = if key.include?('name')
+          key.split('.').map(&:to_sym)
+        elsif key.include?('urn:ietf:params:scim:schemas:extension:enterprise:2.0:User')
+          # This will grab the last part of the key, which is the attribute name
+          key.split(/\:(?=[^:]*$)/).map(&:to_sym)
+        else
+          [key.to_sym]
+        end
+
         leaf = key_parts[0...-1].inject(all) { |h, k| h[k] ||= {} }
         leaf[key_parts.last] = value
       end

--- a/spec/controllers/scim_rails/scim_users_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_request_spec.rb
@@ -68,7 +68,9 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
                 "value": {
                   "userName": "frederique.halvorson@dooley.co.uk",
                   "name.givenName": "Nico",
-                  "name.familyName": "Grayson"
+                  "name.familyName": "Grayson",
+                  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:organization": "Sample Company",
+                  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department": "Sample Department"
                 }
               }.compact,
             ],
@@ -78,6 +80,8 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
         it "updates specific Person attribute" do
           expect(resp).to eq 200
           expect(target_person.reload.first_name).to eq('Nico')
+          expect(subject.company).to eq('Sample Company')
+          expect(subject.department).to eq('Sample Department')
         end
       end
     end

--- a/spec/controllers/scim_rails/scim_users_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_request_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
                   "userName": "frederique.halvorson@dooley.co.uk",
                   "name.givenName": "Nico",
                   "name.familyName": "Grayson",
-                  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:organization": "Sample Company",
                   "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department": "Sample Department"
                 }
               }.compact,
@@ -80,8 +79,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
         it "updates specific Person attribute" do
           expect(resp).to eq 200
           expect(target_person.reload.first_name).to eq('Nico')
-          expect(subject.organization).to eq('Sample Company')
-          expect(subject.department).to eq('Sample Department')
+          expect(target_person.reload.department).to eq('Sample Department')
         end
       end
     end

--- a/spec/controllers/scim_rails/scim_users_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_request_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
         it "updates specific Person attribute" do
           expect(resp).to eq 200
           expect(target_person.reload.first_name).to eq('Nico')
-          expect(subject.company).to eq('Sample Company')
+          expect(subject.organization).to eq('Sample Company')
           expect(subject.department).to eq('Sample Department')
         end
       end


### PR DESCRIPTION
## Why?

What is the problem this PR attempts to solve, and why is it important? Fixing a bug? Explain the problem you're solving. Laying a foundation for future work? Explain how this fits into the bigger picture.

https://tractionguest.atlassian.net/browse/AT1-154

## What?

What does this PR change, and how does that solve the problem noted above? Call out any related changes, and add before-and-after screenshots for UI updates.

The company name and department name were not being updated with how azure is they are sending there https request. 
I initially thought the changes I added recently broke it. However, it was broken before. So I enhanced the logic to handle the two scenarios that were failing. Below is a sample request of what azure is sending us:

{
   "op": "replace",
  "value": {
    "userName": "frederique.halvorson@dooley.co.uk",
    "name.givenName": "Nico",
    "name.familyName": "Grayson",
    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:organization": "Sample Company",
    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department": "Sample Department"
  }
}

## Caveats

Are there downsides or side-effects that should be weighed against this update? Any lingering unknowns or things you can’t test without production data or traffic?

## Testing Notes

Is any special setup required to test this change? Non-obvious things that should be checked?

A list of things to test:

- [ ] Test item 1
- [ ] Test item 2
- [ ] Test item 3

## Alternatives Considered

Were there other approaches or solutions to this problem which you considered? Why were they not chosen?

## Further Reading

Were there articles or StackOverflow answers you found especially eye-opening when working on this? Slack conversation around this? Provide a link to the thread.

## Merge Instructions

Please **DO NOT** squash my commits when merging
