### PR TITLE
[feature-kube-core-92] update user lookup by email

### DIFF
--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -40,7 +40,7 @@ module ScimRails
       if ScimRails.config.scim_user_prevent_update_on_create
         user = @company.public_send(ScimRails.config.scim_users_scope).create!(user_params)
       else
-        username_key = ScimRails.config.queryable_user_attributes[:userName]
+        username_key = ScimRails.config.queryable_user_attributes[:email]
 
         find_by_params = Hash.new
 

--- a/spec/controllers/scim_rails/scim_users_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_request_spec.rb
@@ -59,6 +59,10 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
             ScimRails.config.scim_user_prevent_update_on_create = true
           end
 
+          after do
+            ScimRails.config.scim_user_prevent_update_on_create = false
+          end
+
           it 'does not update the existing user' do
             post '/scim_rails/scim/v2/Users', params: params.to_json, headers: valid_authentication_header
 
@@ -72,10 +76,6 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
         context 'when scim_user_prevent_update_on_create is false' do
           before do
             ScimRails.config.scim_user_prevent_update_on_create = false
-          end
-
-          after do
-            ScimRails.config.scim_user_prevent_update_on_create = true
           end
 
           it 'updates the existing user' do

--- a/spec/controllers/scim_rails/scim_users_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_request_spec.rb
@@ -74,6 +74,10 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
             ScimRails.config.scim_user_prevent_update_on_create = false
           end
 
+          after do
+            ScimRails.config.scim_user_prevent_update_on_create = true
+          end
+
           it 'updates the existing user' do
             post '/scim_rails/scim/v2/Users', params: params.to_json, headers: valid_authentication_header
 

--- a/spec/controllers/scim_rails/scim_users_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_request_spec.rb
@@ -47,6 +47,43 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
         expect(response.media_type).to eq "application/scim+json"
         expect(company.users.count).to eq 1
       end
+
+      context 'when user already exists' do
+        let(:first_name) { Faker::Name.first_name }
+        let(:last_name) { Faker::Name.last_name }
+        let(:email) { 'new@example.com' }
+        let!(:user) { create(:user, first_name: first_name, last_name: last_name, company: company, email: email) }
+
+        context 'when scim_user_prevent_update_on_create is true' do
+          before do
+            ScimRails.config.scim_user_prevent_update_on_create = true
+          end
+
+          it 'does not update the existing user' do
+            post '/scim_rails/scim/v2/Users', params: params.to_json, headers: valid_authentication_header
+
+            expect(response.status).to eq 409
+            expect(company.users.count).to eq 1
+            expect(company.users.first.first_name).to eq first_name
+            expect(company.users.first.last_name).to eq last_name
+          end
+        end
+
+        context 'when scim_user_prevent_update_on_create is false' do
+          before do
+            ScimRails.config.scim_user_prevent_update_on_create = false
+          end
+
+          it 'updates the existing user' do
+            post '/scim_rails/scim/v2/Users', params: params.to_json, headers: valid_authentication_header
+
+            expect(response.status).to eq 201
+            expect(company.users.count).to eq 1
+            expect(company.users.first.first_name).to eq 'New'
+            expect(company.users.first.last_name).to eq 'User'
+          end
+        end
+      end
     end
 
     describe 'patch' do


### PR DESCRIPTION
## Why?

https://tractionguest.atlassian.net/browse/CORE-92

## What?

Currently we have an issue where are getting duplicate hosts in SIE. To solve this will be twofolds.
The first will need to be addressed in this gem. Currently the gem does a lookup of existing users by username. The reason this does not work is because no host have the username attribute filled in unless it has been imported by scim. The issue with that is if a company has been uploading host by csv or manually creating them. They don't input the username. When the migrate to use scim ... all host created before get duplicated because they lookup a user by username. To change this behavior we need to update the lookup to be by email as it is required in SIE

## Caveats

We will need to update the following config in guest-server from true to false:
scim_user_prevent_update_on_create

## Testing Notes

Is any special setup required to test this change? Non-obvious things that should be checked?

A list of things to test:

- [ ] Test item 1
- [ ] Test item 2
- [ ] Test item 3

## Alternatives Considered

Were there other approaches or solutions to this problem which you considered? Why were they not chosen?

## Further Reading

Were there articles or StackOverflow answers you found especially eye-opening when working on this? Slack conversation around this? Provide a link to the thread.

## Merge Instructions

Please **DO NOT** squash my commits when merging
