### PR TITLE
[CORE-92] Handle lookup of users by email to prevent duplicate host from being created.

### DIFF
--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -42,9 +42,6 @@ module ScimRails
       else
         username_key = ScimRails.config.queryable_user_attributes[:userName]
         email_key = ScimRails.config.queryable_user_attributes[:email]
-
-        byebug
-
         user = username_key.present? ? find_user_by_key(username_key, user_params) : find_user_by_key(email_key, user_params)
 
         user.update!(user_params)

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -40,16 +40,13 @@ module ScimRails
       if ScimRails.config.scim_user_prevent_update_on_create
         user = @company.public_send(ScimRails.config.scim_users_scope).create!(user_params)
       else
-        username_key = ScimRails.config.queryable_user_attributes[:email]
+        username_key = ScimRails.config.queryable_user_attributes[:userName]
+        email_key = ScimRails.config.queryable_user_attributes[:email]
 
-        find_by_params = Hash.new
+        byebug
 
-        find_by_params[username_key] = user_params[username_key]
-        find_by_params[ScimRails.config.basic_auth_model.to_s.underscore] = @company
+        user = username_key.present? ? find_user_by_key(username_key, user_params) : find_user_by_key(email_key, user_params)
 
-        user = ScimRails.config.scim_users_model
-          .unscoped # Specific to our use case and should be changed back after we remove the default_scope from our "User" model
-          .find_or_initialize_by(find_by_params)
         user.update!(user_params)
       end
       update_status(user) unless params[:active].nil?
@@ -167,6 +164,14 @@ module ScimRails
         leaf = key_parts[0...-1].inject(all) { |h, k| h[k] ||= {} }
         leaf[key_parts.last] = value
       end
+    end
+
+    def find_user_by_key(key, user_params)
+      find_by_params = Hash.new
+      find_by_params[key] = user_params[key]
+      find_by_params[ScimRails.config.basic_auth_model.to_s.underscore] = @company
+
+      ScimRails.config.scim_users_model.unscoped.find_or_initialize_by(find_by_params)
     end
   end
 end


### PR DESCRIPTION
## Why?

(https://tractionguest.atlassian.net/browse/CORE-92)

## What?

This logic solves two problems:
1. When searching for a user by username, we will find users that have username populated. This only occurs if the user was created by SCIM.
2. When searching for a user by email, we will find users that have emails populated. This will allow us to migrate users from a non-SCIM user to a SCIM user.
The second item will prevent duplicate host from being created in the guest-server.

We could address this in the guest-server config scim file. However, if we updated the mapping to have username: :email. We would break the account GORE. This approach will leave things working like they were but add another check if we can't find a persisted user with username. We try and use the lookup by email. Otherwise we would create a new user like we always have.

## Caveats

Couldn't write specific test for username without mucking up a bunch of stuff. I do have test written out in guest server when I merge this. 

## Testing Notes

Is any special setup required to test this change? Non-obvious things that should be checked?

A list of things to test:

- [ ] Test item 1
- [ ] Test item 2
- [ ] Test item 3

## Alternatives Considered

Were there other approaches or solutions to this problem which you considered? Why were they not chosen?

## Further Reading

Were there articles or StackOverflow answers you found especially eye-opening when working on this? Slack conversation around this? Provide a link to the thread.

## Merge Instructions

Please **DO NOT** squash my commits when merging
