### PR TITLE
Relax gem dependencies

### DIFF
--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,3 +1,3 @@
 module ScimRails
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end

--- a/scim_rails.gemspec
+++ b/scim_rails.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.required_ruby_version = "~> 2.7"
-  s.add_dependency "rack", "~> 2.2.3"
-  s.add_dependency "rails", "~> 6.1.7", ">= 6.1.7.3"
-  s.add_dependency "nokogiri"
+  s.add_dependency "rack", ">= 2.2.3", "< 4.0"
+  s.add_dependency "rails", ">= 6.1.7.3", "< 7.0"
+  s.add_dependency "nokogiri", "~> 1.13"
   s.add_runtime_dependency "jwt", ">= 1.5", "< 3.0"
   s.test_files = Dir["spec/**/*"]
 


### PR DESCRIPTION
This gem has very specific version-requirements for its transitive dependencies. This makes it difficult to include in another application without incurring version-mismatch errors.