### PR TITLE
[VMC-257] Include members to reduce N+1 queries

### DIFF
--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -6,12 +6,11 @@ module ScimRails
       if params[:filter].present?
         query = ScimRails::ScimQueryParser.new(params[:filter])
 
-        groups = @company.public_send(ScimRails.config.scim_groups_scope)
-                         .where("lower(#{ScimRails.config.scim_groups_model.connection.quote_column_name(query.group_attribute).gsub("\"", "")}) = ?", query.parameter.downcase)
-                         .order(ScimRails.config.scim_groups_list_order)
+        groups = groups_scope
+                   .where("lower(#{ScimRails.config.scim_groups_model.connection.quote_column_name(query.group_attribute).gsub("\"", "")}) = ?", query.parameter.downcase)
+                   .order(ScimRails.config.scim_groups_list_order)
       else
-        groups = @company.public_send(ScimRails.config.scim_groups_scope)
-                         .order(ScimRails.config.scim_groups_list_order)
+        groups = groups_scope.order(ScimRails.config.scim_groups_list_order)
       end
 
       counts = ScimCount.new(
@@ -48,18 +47,15 @@ module ScimRails
 
     def show
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
-
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
-
+      group = groups_scope.find(params[:id])
       ScimRails.config.after_scim_response.call(group, "RETRIEVED") unless ScimRails.config.after_scim_response.nil?
-
       json_scim_group_response(object: group)
     end
 
     def put_update
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
+      group = groups_scope.find(params[:id])
 
       put_error_check
 
@@ -81,7 +77,7 @@ module ScimRails
     def patch_update
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
-      group = @company.public_send(ScimRails.config.scim_groups_scope).find(params[:id])
+      group = groups_scope.find(params[:id])
 
       group.update!(ScimRails.config.custom_group_attributes)
 
@@ -272,6 +268,12 @@ module ScimRails
 
     def array_of_hashes?(array)
       array.all? { |hash| hash.is_a?(ActionController::Parameters) }
+    end
+
+    def groups_scope
+      @company
+        .public_send(ScimRails.config.scim_groups_scope)
+        .includes(ScimRails.config.scim_group_member_scope)
     end
   end
 end


### PR DESCRIPTION
This PR reduces an N+1 DB queries situation in a few endpoints, in the `ScimRails::ScimGroupController` endpoint. Namely:

- `index`
- `show`
- `put_update`
- `patch_update`

All of these endpoints first query for the `ScimRails.config.scim_group_scope` model (ie: `PersonGroup` in our case), and then later iterates over the `ScimRails.config.scim_group_member_scope` model (ie: `Person` in our case). The former happens in `ScimRails::ScimGroupController` and the latter happens in `ScimRails::Response` (see [`group_response`](https://github.com/tractionguest/scim_rails/blob/9fd92cca39ecf732ffcd995ce4eb17cd88065bfd/app/controllers/concerns/scim_rails/response.rb#L114-L129)); however, `ScimRails::Response` always iterates over the full list of "member" records.

The improvement is here is the classic solution to N+1 requests in Rails: with an `includes` clause on the original query.

### Note

The `patch_update` endpoint, in particular, is called very often. This one endpoint individually accounts for 15% of all our DB resource usage, so improvements here go a long way.

