### PR TITLE
[CORE-2159] Updates rack-session patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scim_rails (0.9.0)
+    scim_rails (0.9.1)
       jwt (>= 1.5, < 3.0)
       nokogiri (~> 1.15)
       rack (>= 2.2.3, < 4.0)
@@ -171,7 +171,7 @@ GEM
       stringio
     racc (1.8.1)
     rack (3.2.5)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ScimRails
-  VERSION = '0.9.0'
+  VERSION = '0.9.1'
 end


### PR DESCRIPTION
## Why?

Because bumping from 2.1.1 to 2.1.2 will fix CVE-2026-39324

## What?

Gemfile.lock via `bundle update rack-session --conservative` command. This upgrades only 1 patch version, so it should be safe to update. I reviewed the changelog https://github.com/rack/rack-session/compare/v2.1.1...v2.1.2 and this update does not need any application code change, it contains no breaking changes.

## Caveats

No

## Testing Notes

No. Smoke tests are enough.

## Alternatives Considered

There are no alternatives to consider.

## Further Reading

- Look for CVE-2026-39324
- Read the code changes in the changelog linked above.

## Merge Instructions

Consider publishing a new release: 0.9.1