### PR TITLE
Feature kube core 2169

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
     regexp_parser (2.8.1)
     reline (0.6.3)
       io-console (~> 0.5)
-    rexml (3.2.5)
+    rexml (3.4.4)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ScimRails
-  VERSION = '0.9.2'
+  VERSION = '0.9.3'
 end


### PR DESCRIPTION
## Summary                                                                                                                                                                                                  
                                                                                                                                                                                                              
  - Upgrades `rexml` from 3.2.5 to 3.4.4 to fix an XML External Entity (XXE) vulnerability where specially crafted XML documents with deeply nested elements could cause excessive resource consumption.
  - `rexml` is a transitive dependency introduced through `rubocop`, `rubocop-rails`, and `rubocop-rspec` — not used directly in application code.

  ## Risk assessment

  Low. The vulnerability requires parsing untrusted XML via tree parser APIs (`REXML::Document.new`), which doesn't apply here since `rexml` is only used by development/CI tooling (linters). The upgrade is
  preventive housekeeping to clear the security advisory.

  ## Test plan

  - [ ] CI green — `bundle exec rspec` passes
  - [ ] Verify rubocop still runs correctly with the updated dependency