### PR TITLE
Prepare for v0.10.0 vulnerabilities/performance release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scim_rails (0.8.0)
+    scim_rails (0.9.0)
       jwt (>= 1.5, < 3.0)
       nokogiri (~> 1.15)
       rack (>= 2.2.3, < 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scim_rails (0.9.0)
+    scim_rails (0.9.1)
       jwt (>= 1.5, < 3.0)
       nokogiri (~> 1.15)
       rack (>= 2.2.3, < 4.0)
@@ -171,7 +171,7 @@ GEM
       stringio
     racc (1.8.1)
     rack (3.2.5)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     diff-lcs (1.5.0)
     docile (1.4.0)
     drb (2.2.3)
-    erb (6.0.1)
+    erb (6.0.4)
     erubi (1.13.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     minitest (6.0.1)
       prism (~> 1.5)
     mutex_m (0.3.0)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -272,7 +272,7 @@ GEM
       mini_portile2 (~> 2.8.0)
     stringio (3.2.0)
     thor (1.5.0)
-    timeout (0.6.0)
+    timeout (0.6.1)
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.0)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     observer (0.1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scim_rails (0.9.4)
+    scim_rails (0.10.0)
       jwt (>= 1.5, < 3.0)
       nokogiri (~> 1.15)
       rack (>= 2.2.3, < 4.0)

--- a/app/controllers/scim_rails/scim_groups_controller.rb
+++ b/app/controllers/scim_rails/scim_groups_controller.rb
@@ -75,7 +75,11 @@ module ScimRails
     def patch_update
       ScimRails.config.before_scim_response.call(request.params) unless ScimRails.config.before_scim_response.nil?
 
-      group = groups_scope.find(params[:id])
+      group = if params[:attributes].present?
+        groups_scope.find(params[:id])
+      else
+        groups_scope_without_members.find(params[:id])
+      end
       group.update!(ScimRails.config.custom_group_attributes) if group_attributes_changed?(group)
 
       if params.key?("members")
@@ -86,7 +90,11 @@ module ScimRails
 
       ScimRails.config.after_scim_response.call(group, "UPDATED") unless ScimRails.config.after_scim_response.nil?
 
-      json_scim_group_response(object: group)
+      if params[:attributes].present?
+        json_scim_group_response(object: group)
+      else
+        head :no_content
+      end
     end
 
     def delete
@@ -276,6 +284,10 @@ module ScimRails
         @company
           .public_send(ScimRails.config.scim_groups_scope)
           .includes(ScimRails.config.scim_group_member_scope)
+    end
+
+    def groups_scope_without_members
+      @company.public_send(ScimRails.config.scim_groups_scope)
     end
 
     def all_users_scope

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -122,7 +122,13 @@ module ScimRails
     private
 
     def get_multi_value_attrs(operation)
-      schema_hash = contains_square_brackets?(operation["path"]) ? multi_attr_type_to_value(process_filter_path(operation)) : {}
+      if contains_square_brackets?(operation["path"])
+        multi_attr_type_to_value(process_filter_path(operation))
+      elsif operation["value"].is_a?(Hash)
+        multi_attr_type_to_value(operation["value"])
+      else
+        {}
+      end
     end
 
     def check_allowed_parameters!

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -103,7 +103,11 @@ module ScimRails
 
       ScimRails.config.after_scim_response.call(user, "UPDATED") unless ScimRails.config.after_scim_response.nil?
 
-      json_scim_response(object: user)
+      if params[:attributes].present?
+        json_scim_response(object: user)
+      else
+        head :no_content
+      end
     end
 
     def delete

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ScimRails
-  VERSION = '0.9.0'
+  VERSION = '0.9.1'
 end

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ScimRails
-  VERSION = '0.9.4'
+  VERSION = '0.10.0'
 end

--- a/spec/controllers/scim_rails/scim_groups_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_groups_controller_spec.rb
@@ -588,7 +588,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
           let(:replacement_ids) { replacement_users.map{ |user| user[:id] } }
 
           context "when updating non-member attributes" do
-            after { expect(response.status).to eq(200) }
+            after { expect(response.status).to eq(204) }
 
             context "with active param not in use" do
               subject { updated_group.display_name }
@@ -646,7 +646,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
               let(:patch_value) { [ { value: replacement_ids[0] }, { value: replacement_ids[1] } ] }
 
               it "replaces the group's member list" do
-                expect(response.status).to eq(200)
+                expect(response.status).to eq(204)
                 expect(updated_user_list.length).to eq(replacement_list_length)
                 expect(updated_user_ids).to match_array(replacement_ids)
               end
@@ -656,7 +656,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
               let(:patch_value) { [] }
 
               it "clears the group's member list" do
-                expect(response.status).to eq(200)
+                expect(response.status).to eq(204)
                 expect(updated_user_list).to be_empty
               end
             end
@@ -674,7 +674,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
                 let(:patch_value) { [ { value: new_user.id } ] }
 
                 it "adds the user to the group" do
-                  expect(response.status).to eq(200)
+                  expect(response.status).to eq(204)
                   expect(updated_user_list.length).to eq(user_list_length + 1)
                   expect(updated_user_ids).to include(new_user.id)
                 end
@@ -708,7 +708,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
                 let(:alt_patch) { patch :patch_update, params: alt_params, as: :json }
 
                 it "only adds member to group once" do
-                  expect(response.status).to eq(200)
+                  expect(response.status).to eq(204)
                   expect(updated_user_list.length).to eq(user_list_length + 1)
                   expect(updated_user_ids).to include(new_user.id)
 
@@ -721,8 +721,8 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
               let(:patch_path) { "externalId" }
               let(:patch_value) { "10aa0369-2539-405f-b4f5-32be6ab6f88a" }
 
-              it "returns 200 and treats as attribute update" do
-                expect(response.status).to eq(200)
+              it "returns 204 and treats as attribute update" do
+                expect(response.status).to eq(204)
               end
 
               it "does not change group members" do
@@ -736,7 +736,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
               let(:patch_value) { [ { value: new_user.id } ] }
 
               it "adds the user to the group" do
-                expect(response.status).to eq(200)
+                expect(response.status).to eq(204)
                 expect(updated_user_list.length).to eq(user_list_length + 1)
                 expect(updated_user_ids).to include(new_user.id)
               end
@@ -746,7 +746,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
               let(:patch_value) { [ { value: new_user.id }, { value: new_user.id } ] }
 
               it "only adds one of the users" do
-                expect(response.status).to eq(200)
+                expect(response.status).to eq(204)
                 expect(updated_user_list.length).to eq(user_list_length + 1)
                 expect(updated_user_ids).to include(new_user.id)
               end
@@ -764,7 +764,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
               let(:patch_path) { "members[value eq \"#{target_user_id}\"]" }
 
               it "removes member from group" do
-                expect(response.status).to eq(200)
+                expect(response.status).to eq(204)
                 expect(updated_user_list.length).to eq(user_list_length - 1)
                 expect(updated_user_ids).to_not include(target_user_id)
               end
@@ -774,7 +774,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
               let(:patch_path) { "members[value eq \"unknown\"]" }
 
               it "does not remove anything" do
-                expect(response.status).to eq(200)
+                expect(response.status).to eq(204)
                 expect(updated_user_list.length).to eq(user_list_length)
               end
             end
@@ -783,7 +783,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
               let(:patch_path) { "members" }
 
               it "clears the group's members" do
-                expect(response.status).to eq(200)
+                expect(response.status).to eq(204)
                 expect(updated_user_list).to be_empty
               end
             end
@@ -812,7 +812,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
               let(:patch_value) { [{ value: target_user_id }] }
 
               it "removes member from group" do
-                expect(response.status).to eq(200)
+                expect(response.status).to eq(204)
                 expect(updated_user_list.length).to eq(user_list_length - 1)
                 expect(updated_user_ids).to_not include(target_user_id)
               end
@@ -847,7 +847,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
           let(:patch_members) { [{ value: new_user.id }, { value: second_new_user.id }] }
 
           it "adds new users to group" do
-            expect(response.status).to eq(200)
+            expect(response.status).to eq(204)
 
             expect(company.groups.first.users).to include(new_user)
             expect(company.groups.first.users).to include(second_new_user)
@@ -858,7 +858,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
           let(:patch_members) { [{ value: target_user_id, operation: "delete" }] }
 
           it "removes user from group" do
-            expect(response.status).to eq(200)
+            expect(response.status).to eq(204)
 
             expect(updated_user_ids).not_to include(target_user_id)
           end
@@ -881,7 +881,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
           end
 
           it "adds and removes respective users from group" do
-            expect(response.status).to eq(200)
+            expect(response.status).to eq(204)
 
             expect(company.groups.first.users).to include(new_user)
             expect(company.groups.first.users).to include(second_new_user)
@@ -894,7 +894,7 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
           let(:patch_members) { [{ value: target_user_id, operation: "hamburger" }] }
 
           it "does not change the user list" do
-            expect(response.status).to eq(200)
+            expect(response.status).to eq(204)
 
             expect(updated_user_list.length).to eq(user_list_length)
           end
@@ -933,11 +933,93 @@ RSpec.describe ScimRails::ScimGroupsController, type: :controller do
         end
 
         it "successfully performs all three" do
-          expect(response.status).to eq(200)
+          expect(response.status).to eq(204)
           expect(updated_group.display_name).to eq(new_display_name)
           expect(updated_group.email).to eq(new_email)
           expect(updated_user_list.length).to eq(1)
           expect(updated_user_ids).to include(new_user.id)
+        end
+      end
+    end
+
+    context 'when authorized (no before block)' do
+      before :each do
+        http_login(company)
+      end
+
+      let(:user_list_length) { 3 }
+      let!(:user_list) { create_list(:user, user_list_length, company: company) }
+      let!(:target_group) { create(:group, users: user_list, company: company) }
+
+      context 'when attributes query parameter is present' do
+        it 'returns 200 with the group resource' do
+          patch :patch_update, params: {
+            id: target_group.id,
+            attributes: 'displayName',
+            Operations: [
+              {
+                op: 'replace',
+                value: { displayName: 'New Name' }
+              }
+            ]
+          }, as: :json
+
+          expect(response.status).to eq 200
+          expect(response.media_type).to eq 'application/scim+json'
+
+          response_body = JSON.parse(response.body)
+          expect(response_body['id']).to eq target_group.id
+          expect(response_body['displayName']).to eq 'New Name'
+        end
+      end
+
+      context 'when attributes query parameter is absent' do
+        it 'returns 204 with no content' do
+          patch :patch_update, params: {
+            id: target_group.id,
+            Operations: [
+              {
+                op: 'replace',
+                value: { displayName: 'New Name' }
+              }
+            ]
+          }, as: :json
+
+          expect(response.status).to eq 204
+          expect(response.body).to be_empty
+        end
+
+        it 'still applies the changes to the group' do
+          patch :patch_update, params: {
+            id: target_group.id,
+            Operations: [
+              {
+                op: 'replace',
+                value: { displayName: 'Updated Name' }
+              }
+            ]
+          }, as: :json
+
+          expect(response.status).to eq 204
+          expect(target_group.reload.display_name).to eq 'Updated Name'
+        end
+
+        it 'still adds members to the group' do
+          new_user = create(:user, company: company)
+
+          patch :patch_update, params: {
+            id: target_group.id,
+            Operations: [
+              {
+                op: 'add',
+                path: 'members',
+                value: [{ value: new_user.id }]
+              }
+            ]
+          }, as: :json
+
+          expect(response.status).to eq 204
+          expect(target_group.reload.users).to include(new_user)
         end
       end
     end

--- a/spec/controllers/scim_rails/scim_users_controller_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_controller_spec.rb
@@ -556,8 +556,8 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
         http_login(company)
       end
 
-      it "returns scim+json content type" do
-        patch :patch_update, params: patch_params(id: 1)
+      it "returns scim+json content type when attributes param is present" do
+        patch :patch_update, params: patch_params(id: 1).merge(attributes: 'userName')
 
         expect(response.media_type).to eq "application/scim+json"
       end
@@ -565,7 +565,28 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
       it "is successful with valid credentials" do
         patch :patch_update, params: patch_params(id: 1)
 
-        expect(response.status).to eq 200
+        expect(response.status).to eq 204
+      end
+
+      context 'when attributes query parameter is present' do
+        it 'returns 200 with the user resource' do
+          patch :patch_update, params: patch_params(id: 1).merge(attributes: 'userName')
+
+          expect(response.status).to eq 200
+          expect(response.media_type).to eq 'application/scim+json'
+
+          response_body = JSON.parse(response.body)
+          expect(response_body['id']).to eq 1
+        end
+      end
+
+      context 'when attributes query parameter is absent' do
+        it 'returns 204 with no content' do
+          patch :patch_update, params: patch_params(id: 1)
+
+          expect(response.status).to eq 204
+          expect(response.body).to be_empty
+        end
       end
 
       it "returns :not_found for id that cannot be found" do
@@ -607,7 +628,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
 
         patch :patch_update, params: patch_params(id: 1)
 
-        expect(response.status).to eq 200
+        expect(response.status).to eq 204
         expect(company.users.count).to eq 1
         user.reload
         expect(user.archived?).to eq true
@@ -620,7 +641,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
 
         patch :patch_update, params: patch_params(id: 1,  active: true)
 
-        expect(response.status).to eq 200
+        expect(response.status).to eq 204
         expect(company.users.count).to eq 1
         user.reload
         expect(user.archived?).to eq false
@@ -651,7 +672,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
             ]
           }
 
-          expect(response.status).to eq(200)
+          expect(response.status).to eq(204)
           expect(company_user.first_name).to eq(new_given_name)
           expect(company_user.last_name).to eq(new_family_name)
         end
@@ -673,7 +694,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
               ]
            }
 
-           expect(response.status).to eq(200)
+           expect(response.status).to eq(204)
            expect(company_user.email).to eq(new_email)
         end
 
@@ -702,7 +723,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :controller do
             ]
           }
 
-          expect(response.status).to eq(200)
+          expect(response.status).to eq(204)
           expect(company_user.first_name).to eq(final_given_name)
           expect(company_user.last_name).to eq(final_family_name)
         end

--- a/spec/controllers/scim_rails/scim_users_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_request_spec.rb
@@ -127,6 +127,34 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
           expect(target_person.reload.department).to eq('Sample Department')
         end
       end
+
+      context 'with multi-valued attributes in value (no filter path)' do
+        let(:work_email) { 'work@example.com' }
+        let(:other_email) { 'other@example.com' }
+        let(:params) do
+          {
+            id: target_person.id,
+            Operations: [
+              {
+                'op' => 'replace',
+                'value' => {
+                  'emails' => [
+                    { 'type' => 'other', 'value' => other_email },
+                    { 'type' => 'work', 'value' => work_email }
+                  ]
+                }
+              }
+            ]
+          }
+        end
+
+        it 'maps attributes by type, not by position' do
+          expect(resp).to eq 200
+          target_person.reload
+          expect(target_person.email).to eq(work_email)
+          expect(target_person.alternate_email).to eq(other_email)
+        end
+      end
     end
   end
 end

--- a/spec/dummy/config/initializers/scim_rails_config.rb
+++ b/spec/dummy/config/initializers/scim_rails_config.rb
@@ -20,8 +20,16 @@ ScimRails.configure do |config|
   config.mutable_user_attributes = [
     :first_name,
     :last_name,
-    :email
+    :email,
+    :alternate_email
   ]
+
+  config.scim_attribute_type_mappings = {
+    'emails' => {
+      'work' => :email,
+      'other' => :alternate_email
+    }
+  }
 
   config.queryable_user_attributes = {
     userName: :email,
@@ -38,6 +46,9 @@ ScimRails.configure do |config|
     emails: [
       {
         value: :email
+      },
+      {
+        value: :alternate_email
       }
     ]
   }


### PR DESCRIPTION
This PR includes recent performance improvements and vulnerability fixes, including:

- [VMC-527](https://linear.app/signinsolutions/issue/VMC-527): Update net-imap to v0.6.4
- [VMC-528](https://linear.app/signinsolutions/issue/VMC-528): Update nokogiri to v1.19.3
- [VMC-529](https://linear.app/signinsolutions/issue/VMC-529): Update erb to v6.0.4
- [VMC-257](https://linear.app/signinsolutions/issue/VMC-257): Reduce SCIM N+1 Queries
- [VMC-295](https://linear.app/signinsolutions/issue/VMC-295): Do not fetch group members, unless asked

Once this PR is merged up, I'll create a new Gem release, and update `guest-server` to use it.
