### PR TITLE
bump rack gem to v3.2.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
       date
       stringio
     racc (1.8.1)
-    rack (3.2.5)
+    rack (3.2.6)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)


### PR DESCRIPTION
This tiny PR updates `rack` to avoid a couple critical vulnerability, namely:

- https://signinsolutions.atlassian.net/browse/CORE-2196
- https://signinsolutions.atlassian.net/browse/CORE-2199