### PR TITLE
[VMC-589] Fixes broken test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scim_rails (0.10.0)
+    scim_rails (0.10.1)
       jwt (>= 1.5, < 3.0)
       nokogiri (~> 1.15)
       rack (>= 2.2.3, < 4.0)

--- a/app/controllers/scim_rails/scim_users_controller.rb
+++ b/app/controllers/scim_rails/scim_users_controller.rb
@@ -128,7 +128,7 @@ module ScimRails
     def get_multi_value_attrs(operation)
       if contains_square_brackets?(operation["path"])
         multi_attr_type_to_value(process_filter_path(operation))
-      elsif operation["value"].is_a?(Hash)
+      elsif operation["value"].is_a?(Hash) || operation["value"].is_a?(ActionController::Parameters)
         multi_attr_type_to_value(operation["value"])
       else
         {}

--- a/app/services/parameter_service.rb
+++ b/app/services/parameter_service.rb
@@ -11,6 +11,10 @@ module ParameterService
 
     # known
     'schemas',
+
+    # SCIM query params (RFC 7644 §3.9) — control the response, not attributes
+    'attributes',
+    'excludedAttributes',
   ].freeze
 
   # https://datatracker.ietf.org/doc/html/rfc7643#section-4

--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ScimRails
-  VERSION = '0.10.0'
+  VERSION = '0.10.1'
 end

--- a/spec/controllers/scim_rails/scim_users_request_spec.rb
+++ b/spec/controllers/scim_rails/scim_users_request_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
         end
 
         it "updates specific Person attribute" do
-          expect(resp).to eq 200
+          expect(resp).to eq 204
           expect(target_person.reload.first_name).to eq('Nico')
           expect(target_person.reload.department).to eq('Sample Department')
         end
@@ -149,7 +149,7 @@ RSpec.describe ScimRails::ScimUsersController, type: :request do
         end
 
         it 'maps attributes by type, not by position' do
-          expect(resp).to eq 200
+          expect(resp).to eq 204
           target_person.reload
           expect(target_person.email).to eq(work_email)
           expect(target_person.alternate_email).to eq(other_email)


### PR DESCRIPTION
### Task: ###

- https://linear.app/signinsolutions/issue/VMC-589/update-tractionguestscim-rails-gem-to-use-rails-8

### Stacked PRs: ###

- ➡️ Part 1 PR: #73
- Part 2 PR: #74

### Description: ###

ParameterService validates incoming params against the user schema and rejects anything it doesn't recognize. It was missing the SCIM query parameters attributes and excludedAttributes (RFC 7644 3.9), which control the shape of the response rather than being writable attributes.

Because attributes wasn't in `KEYS_TO_IGNORE`, the `check_allowed_parameters!` before-action rejected requests like `PATCH /Users/:id?attributes=userName` with a 400 Unknown fields before `patch_update` could run, so the endpoint never returned 200 with the user resource, and its test failed.

Two related PATCH tests in `scim_users_request_spec.rb` were also failing. Both expected 200 but the endpoint now returns 204: commit a7a3299 ("Return HTTP 204 unless attributes requested") changed `patch_update` to return 204 No Content unless `?attributes=` is requested, and it updated `scim_users_controller_spec.rb` but never updated the request spec. One assertion predated that change (left stale), and the other was added afterward in `b11f242` with the wrong expectation. Both were corrected to 204.

Fixing the status assertion exposed a second issue in the "maps attributes by type" test: `get_multi_value_attrs` only ran its type-based mapping when `operation["value"].is_a?(Hash)`, but in a real request that value is an `ActionController::Parameters` (not a Hash), so the mapping was silently skipped and emails were assigned by array position instead of by SCIM type. `get_multi_value_attrs` now also accepts `ActionController::Parameters`.



###  Changes: ###

- Add attributes and excludedAttributes to ParameterService::KEYS_TO_IGNORE.
- Update two stale 200 → 204 PATCH assertions in scim_users_request_spec.rb.
- Accept ActionController::Parameters (not just Hash) in get_multi_value_attrs so email type-mapping runs on real requests.


- Bump gem version to v0.10.1.